### PR TITLE
nbtc: rename swap to buy and improve code style

### DIFF
--- a/nbtc_swap/Move.lock
+++ b/nbtc_swap/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "57B6AA7CE96B6356DD19EAA52B88747A109A0F62723BAD507F616D7BF2708B60"
+manifest_digest = "037E6989813FAC31A49D903C9FED8E9589430DA9DA0B03F0147B52D0C2CC8E1D"
 deps_digest = "397E6A9F7A624706DBDFEE056CE88391A15876868FD18A88504DA74EB458D697"
 dependencies = [
   { id = "Bridge", name = "Bridge" },
@@ -22,7 +22,7 @@ dependencies = [
 
 [[move.package]]
 id = "Bridge"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "04f11afaf5e0", subdir = "crates/sui-framework/packages/bridge" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "e54b798790ed", subdir = "crates/sui-framework/packages/bridge" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -32,11 +32,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "04f11afaf5e0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "e54b798790ed", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "04f11afaf5e0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "e54b798790ed", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -44,7 +44,7 @@ dependencies = [
 
 [[move.package]]
 id = "SuiSystem"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "04f11afaf5e0", subdir = "crates/sui-framework/packages/sui-system" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "e54b798790ed", subdir = "crates/sui-framework/packages/sui-system" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -64,7 +64,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.46.2"
+compiler-version = "1.48.0"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/nbtc_swap/README.md
+++ b/nbtc_swap/README.md
@@ -6,18 +6,18 @@ It operates with a fixed price set by the contract admin and requires the admin 
 
 ## Features
 - For Users:
-    - `swap_sui_for_nbtc(vault: &mut Vault, coin: Coin<SUI>, ctx: &mut TxContext)`: Send a SUI `Coin` to the `Vault` object to receive nBTC.
+    - `buy_nbtc(vault: &mut Vault, coin: Coin<SUI>, ctx: &mut TxContext)`: Send a SUI `Coin` to the `Vault` object to receive nBTC.
 - For Admin (Requires `AdminCap`):
     - `add_nbtc_liquidity(vault: &mut Vault, nbtc_coin: Coin<NBTC>, ...)`: Adds the entire `Coin<NBTC>` provided to the vault's liquidity.
     - `set_price(vault: &mut Vault, new_price: u64, ...)`: Sets the price. `new_price` is the standard rate (e.g., `25000` for 25k SUI per 1 nBTC).
     - `withdraw(vault: &mut Vault, ...)`: Withdraws all SUI and nBTC from the vault to the admin address.
-    - `set_paused(vault: &mut Vault, pause: bool, ...)`: Stops or resumes the `swap_sui_for_nbtc` function.
+    - `set_paused(vault: &mut Vault, pause: bool, ...)`: Stops or resumes the `buy_nbtc` function.
 
 ## Example 
 
 Below is an example of how to call an already deployed and initialized contract on Sui testnet
 ```bash
-sui client call --package 0x4995e309e990a6a93224153108b26bf79197b234c51db6447bbae10b431c42fb --module nbtc_swap --function swap_sui_for_nbtc --args 0xf280477ca196a4bced5e1db4cd82fcdd647b55585b1d3838dcd8e1b829d263a4 0x4931a2cae0091c86776c571e1193025c19930aca30a4dc5f802011605eb34039 --gas-budget 100000000
+sui client call --package 0x4995e309e990a6a93224153108b26bf79197b234c51db6447bbae10b431c42fb --module nbtc_swap --function buy_nbtc --args 0xf280477ca196a4bced5e1db4cd82fcdd647b55585b1d3838dcd8e1b829d263a4 0x4931a2cae0091c86776c571e1193025c19930aca30a4dc5f802011605eb34039 --gas-budget 100000000
 ```
 - PackageID: `0x4995e309e990a6a93224153108b26bf79197b234c51db6447bbae10b431c42fb`
 - Module: `nbtc_swap`

--- a/nbtc_swap/docs/nbtc_swap.md
+++ b/nbtc_swap/docs/nbtc_swap.md
@@ -10,7 +10,7 @@
 -  [Constants](#@Constants_0)
 -  [Function `init`](#(nbtc_swap=0x0)_nbtc_swap_init)
 -  [Function `calculate_price`](#(nbtc_swap=0x0)_nbtc_swap_calculate_price)
--  [Function `swap_sui_for_nbtc`](#(nbtc_swap=0x0)_nbtc_swap_swap_sui_for_nbtc)
+-  [Function `buy_nbtc`](#(nbtc_swap=0x0)_nbtc_swap_buy_nbtc)
 -  [Function `add_nbtc_liquidity`](#(nbtc_swap=0x0)_nbtc_swap_add_nbtc_liquidity)
 -  [Function `withdraw`](#(nbtc_swap=0x0)_nbtc_swap_withdraw)
 -  [Function `set_price`](#(nbtc_swap=0x0)_nbtc_swap_set_price)
@@ -250,13 +250,13 @@
 
 </details>
 
-<a name="(nbtc_swap=0x0)_nbtc_swap_swap_sui_for_nbtc"></a>
+<a name="(nbtc_swap=0x0)_nbtc_swap_buy_nbtc"></a>
 
-## Function `swap_sui_for_nbtc`
+## Function `buy_nbtc`
 
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap_swap_sui_for_nbtc">swap_sui_for_nbtc</a>(vault: &<b>mut</b> (<a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap">nbtc_swap</a>=0x0)::nbtc_swap::Vault, coin: <a href="../dependencies/sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;<a href="../dependencies/sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;, ctx: &<b>mut</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap_buy_nbtc">buy_nbtc</a>(vault: &<b>mut</b> (<a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap">nbtc_swap</a>=0x0)::nbtc_swap::Vault, coin: <a href="../dependencies/sui/coin.md#sui_coin_Coin">sui::coin::Coin</a>&lt;<a href="../dependencies/sui/sui.md#sui_sui_SUI">sui::sui::SUI</a>&gt;, ctx: &<b>mut</b> <a href="../dependencies/sui/tx_context.md#sui_tx_context_TxContext">sui::tx_context::TxContext</a>)
 </code></pre>
 
 
@@ -265,7 +265,7 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap_swap_sui_for_nbtc">swap_sui_for_nbtc</a>(vault: &<b>mut</b> <a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap_Vault">Vault</a>, coin: Coin&lt;SUI&gt;, ctx: &<b>mut</b> TxContext) {
+<pre><code><b>public</b> <b>entry</b> <b>fun</b> <a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap_buy_nbtc">buy_nbtc</a>(vault: &<b>mut</b> <a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap_Vault">Vault</a>, coin: Coin&lt;SUI&gt;, ctx: &<b>mut</b> TxContext) {
     <b>assert</b>!(!vault.<a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap_is_paused">is_paused</a>, <a href="../nbtc_swap/nbtc_swap.md#(nbtc_swap=0x0)_nbtc_swap_EvaultPaused">EvaultPaused</a>);
     <b>let</b> sender = tx_context::sender(ctx);
     <b>let</b> sui_paid = coin.into_balance();

--- a/nbtc_swap/sources/nbtc_swap.move
+++ b/nbtc_swap/sources/nbtc_swap.move
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 module nbtc_swap::nbtc_swap;
 
 use nbtc::nbtc::NBTC;

--- a/nbtc_swap/sources/nbtc_swap.move
+++ b/nbtc_swap/sources/nbtc_swap.move
@@ -25,8 +25,8 @@ public struct Vault has key, store {
     id: UID,
     nbtc_balance: Balance<NBTC>,
     sui_balance: Balance<SUI>,
-    /// 1 nano nBTC price in MIST
-    nnbtc_price: u64,
+    /// 1 satoshi BTC price in MIST
+    satoshi_price: u64,
     admin: address,
     is_paused: bool,
 }
@@ -39,7 +39,7 @@ fun init(ctx: &mut TxContext) {
         id: object::new(ctx),
         nbtc_balance: coin::zero<NBTC>(ctx).into_balance(),
         sui_balance: coin::zero<SUI>(ctx).into_balance(),
-        nnbtc_price: calculate_price(initial_price),
+        satoshi_price: calculate_price(initial_price),
         admin: sender,
         is_paused: false,
     };
@@ -62,7 +62,7 @@ public fun buy_nbtc(vault: &mut Vault, coin: Coin<SUI>, ctx: &mut TxContext) {
 
     let sender = tx_context::sender(ctx);
     let sui_paid = coin.into_balance();
-    let nbtc_to_receive = sui_paid.value() / vault.nnbtc_price;
+    let nbtc_to_receive = sui_paid.value() / vault.satoshi_price;
     assert!(nbtc_to_receive > 0, EInsufficientSuiPayment);
     let vault_nbtc_balance = vault.nbtc_balance.value();
     assert!(vault_nbtc_balance >= nbtc_to_receive, EInsufficientLiquidity);
@@ -101,7 +101,7 @@ public entry fun set_price(
     _ctx: &mut TxContext,
 ) {
     assert!(new_price > 0, EInvalidPrice);
-    vault.nnbtc_price = calculate_price(new_price);
+    vault.satoshi_price = calculate_price(new_price);
 }
 
 public entry fun set_paused(_cap: &AdminCap, vault: &mut Vault, pause: bool, _ctx: &mut TxContext) {
@@ -110,7 +110,7 @@ public entry fun set_paused(_cap: &AdminCap, vault: &mut Vault, pause: bool, _ct
 
 /// returns price of 1 nano nBTC in MIST
 public fun price(vault: &Vault): u64 {
-    vault.nnbtc_price
+    vault.satoshi_price
 }
 
 public fun nbtc_liquidity(vault: &Vault): u64 {

--- a/nbtc_swap/sources/nbtc_swap.move
+++ b/nbtc_swap/sources/nbtc_swap.move
@@ -7,7 +7,7 @@ use sui::balance::{Self, Balance};
 use sui::coin::{Self, Coin};
 use sui::sui::SUI;
 
-const EvaultPaused: u64 = 1;
+const EVaultPaused: u64 = 1;
 const EInsufficientLiquidity: u64 = 2;
 const EInvalidPrice: u64 = 3;
 const EInsufficientSuiPayment: u64 = 4;
@@ -25,7 +25,8 @@ public struct Vault has key, store {
     id: UID,
     nbtc_balance: Balance<NBTC>,
     sui_balance: Balance<SUI>,
-    price_per_nbtc_satoshi_in_mist: u64,
+    /// 1 nano nBTC price in MIST
+    nnbtc_price: u64,
     admin: address,
     is_paused: bool,
 }
@@ -34,22 +35,21 @@ fun init(ctx: &mut TxContext) {
     let initial_price = 25000; //25k SUI per NBTC
     let sender = tx_context::sender(ctx);
 
+    let vault = Vault {
+        id: object::new(ctx),
+        nbtc_balance: coin::zero<NBTC>(ctx).into_balance(),
+        sui_balance: coin::zero<SUI>(ctx).into_balance(),
+        nnbtc_price: calculate_price(initial_price),
+        admin: sender,
+        is_paused: false,
+    };
+
     transfer::transfer(
         AdminCap {
             id: object::new(ctx),
         },
         sender,
     );
-
-    let vault = Vault {
-        id: object::new(ctx),
-        nbtc_balance: coin::zero<NBTC>(ctx).into_balance(),
-        sui_balance: coin::zero<SUI>(ctx).into_balance(),
-        price_per_nbtc_satoshi_in_mist: calculate_price(initial_price),
-        admin: sender,
-        is_paused: false,
-    };
-
     transfer::share_object(vault);
 }
 
@@ -58,19 +58,16 @@ fun calculate_price(price: u64): u64 {
 }
 
 public entry fun swap_sui_for_nbtc(vault: &mut Vault, coin: Coin<SUI>, ctx: &mut TxContext) {
-    assert!(!vault.is_paused, EvaultPaused);
+    assert!(!vault.is_paused, EVaultPaused);
 
     let sender = tx_context::sender(ctx);
     let sui_paid = coin.into_balance();
-
-    let nbtc_to_receive = sui_paid.value() / vault.price_per_nbtc_satoshi_in_mist;
+    let nbtc_to_receive = sui_paid.value() / vault.nnbtc_price;
     assert!(nbtc_to_receive > 0, EInsufficientSuiPayment);
-
-    vault.sui_balance.join(sui_paid);
     let vault_nbtc_balance = vault.nbtc_balance.value();
-
     assert!(vault_nbtc_balance >= nbtc_to_receive, EInsufficientLiquidity);
 
+    vault.sui_balance.join(sui_paid);
     let nbtc_to_send = coin::take(&mut vault.nbtc_balance, nbtc_to_receive, ctx);
 
     transfer::public_transfer(nbtc_to_send, sender);
@@ -86,6 +83,7 @@ public entry fun add_nbtc_liquidity(
     vault.nbtc_balance.join(nbtc_added);
 }
 
+/// sents all nBTC and Sui to admin
 public entry fun withdraw(_cap: &AdminCap, vault: &mut Vault, ctx: &mut TxContext) {
     let nbtc_amount = vault.nbtc_balance.value();
     let sui_amount = vault.sui_balance.value();
@@ -95,7 +93,7 @@ public entry fun withdraw(_cap: &AdminCap, vault: &mut Vault, ctx: &mut TxContex
     transfer::public_transfer(sui_to_withdraw, vault.admin)
 }
 
-// Input the new price in standard units (e.g., 25000 for 25k SUI per NBTC)
+/// Input the new price in standard units (e.g., 25000 for 25k SUI per NBTC)
 public entry fun set_price(
     _cap: &AdminCap,
     vault: &mut Vault,
@@ -103,15 +101,16 @@ public entry fun set_price(
     _ctx: &mut TxContext,
 ) {
     assert!(new_price > 0, EInvalidPrice);
-    vault.price_per_nbtc_satoshi_in_mist = calculate_price(new_price);
+    vault.nnbtc_price = calculate_price(new_price);
 }
 
 public entry fun set_paused(_cap: &AdminCap, vault: &mut Vault, pause: bool, _ctx: &mut TxContext) {
     vault.is_paused = pause;
 }
 
+/// returns price of 1 nano nBTC in MIST
 public fun price(vault: &Vault): u64 {
-    vault.price_per_nbtc_satoshi_in_mist
+    vault.nnbtc_price
 }
 
 public fun nbtc_liquidity(vault: &Vault): u64 {

--- a/nbtc_swap/sources/nbtc_swap.move
+++ b/nbtc_swap/sources/nbtc_swap.move
@@ -13,7 +13,7 @@ const EInvalidPrice: u64 = 3;
 const EInsufficientSuiPayment: u64 = 4;
 
 // SUI has 9 decimals: 1 SUI = 10^9 MIST
-// nBTC has 8 decimals: 1 NBTC = 10^8 satoshi
+// nBTC has 8 decimals: 1 nBTC = 10^8 satoshi
 // The conversion factor for price = 10^9 / 10^8 = 10
 const PRICE_CONVERSION_FACTOR: u64 = 10;
 
@@ -57,7 +57,7 @@ fun calculate_price(price: u64): u64 {
     price  * PRICE_CONVERSION_FACTOR
 }
 
-public entry fun buy_nbtc(vault: &mut Vault, coin: Coin<SUI>, ctx: &mut TxContext) {
+public fun buy_nbtc(vault: &mut Vault, coin: Coin<SUI>, ctx: &mut TxContext) {
     assert!(!vault.is_paused, EVaultPaused);
 
     let sender = tx_context::sender(ctx);
@@ -83,7 +83,7 @@ public entry fun add_nbtc_liquidity(
     vault.nbtc_balance.join(nbtc_added);
 }
 
-/// sents all nBTC and Sui to admin
+/// sends all nBTC and Sui to admin
 public entry fun withdraw(_cap: &AdminCap, vault: &mut Vault, ctx: &mut TxContext) {
     let nbtc_amount = vault.nbtc_balance.value();
     let sui_amount = vault.sui_balance.value();

--- a/nbtc_swap/sources/nbtc_swap.move
+++ b/nbtc_swap/sources/nbtc_swap.move
@@ -13,7 +13,7 @@ const EInvalidPrice: u64 = 3;
 const EInsufficientSuiPayment: u64 = 4;
 
 // SUI has 9 decimals: 1 SUI = 10^9 MIST
-// NBTC has 8 decimals: 1 NBTC = 10^8 satoshi
+// nBTC has 8 decimals: 1 NBTC = 10^8 satoshi
 // The conversion factor for price = 10^9 / 10^8 = 10
 const PRICE_CONVERSION_FACTOR: u64 = 10;
 
@@ -57,7 +57,7 @@ fun calculate_price(price: u64): u64 {
     price  * PRICE_CONVERSION_FACTOR
 }
 
-public entry fun swap_sui_for_nbtc(vault: &mut Vault, coin: Coin<SUI>, ctx: &mut TxContext) {
+public entry fun buy_nbtc(vault: &mut Vault, coin: Coin<SUI>, ctx: &mut TxContext) {
     assert!(!vault.is_paused, EVaultPaused);
 
     let sender = tx_context::sender(ctx);


### PR DESCRIPTION
## Summary by Sourcery

Rename swap operations to a clearer buy API, streamline naming conventions, reorganize initialization logic, and improve code style and documentation.

Enhancements:
- Rename the `swap_sui_for_nbtc` entry function to `buy_nbtc` and update related identifiers.
- Change the `price_per_nbtc_satoshi_in_mist` field to `nnbtc_price` and adjust usages accordingly.
- Standardize constant naming (e.g., `EVaultPaused`) and add an SPDX license header.
- Introduce doc comments (`///`) for public functions and refine inline comments for clarity.
- Reorder the AdminCap transfer logic to follow vault object creation for readability.

Documentation:
- Update nbtc_swap documentation and README examples to reflect the renamed function and identifiers.