### PR TITLE
test:reader unit test

### DIFF
--- a/bitcoin_executor/sources/interpreter.move
+++ b/bitcoin_executor/sources/interpreter.move
@@ -308,7 +308,7 @@ public fun run(script: vector<u8>): bool {
 fun eval(ip: &mut Interpreter, r: ScriptReader): bool {
     ip.reader = r; // init new  reader
     while (!r.end_stream()) {
-        let op = ip.reader.nextOpcode();
+        let op = ip.reader.next_opcode();
 
         if (op == OP_0) {
             ip.op_push_empty_vector();

--- a/bitcoin_executor/sources/reader.move
+++ b/bitcoin_executor/sources/reader.move
@@ -59,9 +59,8 @@ public fun read_byte(r: &mut ScriptReader): u8 {
 }
 
 /// Return the next opcode
-public fun nextOpcode(r: &mut ScriptReader): u8 {
+public fun next_opcode(r: &mut ScriptReader): u8 {
     let opcode = r.read_byte();
-    assert!(isOpSuccess(opcode), EBadOpcode);
     opcode
 }
 

--- a/bitcoin_executor/tests/reader_tests.move
+++ b/bitcoin_executor/tests/reader_tests.move
@@ -1,0 +1,76 @@
+#[test_only]
+module bitcoin_executor::reader_tests;
+
+use bitcoin_executor::reader::{ScriptReader, Self};
+use sui::test_utils::assert_eq;
+
+#[test]
+fun readable() {
+    let r = reader::new(vector[1, 2, 3]);
+
+    assert!(r.readable(1));
+    assert!(r.readable(2));
+    assert!(r.readable(3));
+    assert!(!r.readable(4));
+}
+
+#[test]
+fun end_stream() {
+    let mut r = reader::new(vector[1, 2, 3]);
+    assert!(!r.end_stream());
+    r.read(3);
+    assert!(r.end_stream());
+}
+
+
+#[test]
+fun read_byte() {
+    let mut r = reader::new(vector[1]);
+    assert_eq(r.read_byte(), 1);
+}
+
+
+#[test]
+fun read() {
+    let mut r = reader::new(vector[1, 2, 3]);
+    let b = r.read(2);
+    assert_eq(b, vector[1, 2]);
+    let b = r.read(1);
+    assert_eq(b, vector[3]);
+}
+
+#[test]
+fun next_opcode() {
+    let mut r = reader::new(vector[80, 1, 2]);
+    assert_eq(r.next_opcode(), 80);
+    assert_eq(r.next_opcode(), 1);
+    assert_eq(r.next_opcode(), 2);
+}
+
+#[test, expected_failure(abort_code = reader::EBadReadData)]
+fun read_fail() {
+    let mut r = reader::new(vector[1, 2, 3]);
+    r.read(10);
+    abort
+}
+
+#[test, expected_failure(abort_code = reader::EBadReadData)]
+fun read_fail_empty_script() {
+    let mut r = reader::new(vector[]);
+    r.read(10);
+    abort
+}
+
+#[test, expected_failure(abort_code = reader::EBadReadData)]
+fun read_endstream_script() {
+    let mut r = reader::new(vector[1, 2, 3]);
+    let b = r.read(3);
+    // check data after read
+    assert_eq(b, vector[1, 2, 3]);
+    // check status of reader
+    assert!(r.end_stream());
+    assert!(!r.readable(1));
+    // read more to ensure this must be return error
+    r.read(10);
+    abort
+}

--- a/bitcoin_executor/tests/reader_tests.move
+++ b/bitcoin_executor/tests/reader_tests.move
@@ -51,14 +51,12 @@ fun next_opcode() {
 fun read_fail() {
     let mut r = reader::new(vector[1, 2, 3]);
     r.read(10);
-    abort
 }
 
 #[test, expected_failure(abort_code = reader::EBadReadData)]
 fun read_fail_empty_script() {
     let mut r = reader::new(vector[]);
     r.read(10);
-    abort
 }
 
 #[test, expected_failure(abort_code = reader::EBadReadData)]
@@ -72,5 +70,4 @@ fun read_endstream_script() {
     assert!(!r.readable(1));
     // read more to ensure this must be return error
     r.read(10);
-    abort
 }


### PR DESCRIPTION
## Summary by Sourcery

Close #42 
Add comprehensive unit tests for the ScriptReader in the reader module, rename and streamline opcode reading, and update interpreter usage accordingly

Enhancements:
- Rename nextOpcode to next_opcode and update its invocation in the interpreter
- Remove redundant isOpSuccess assertion from opcode reader

Tests:
- Introduce reader_tests module with tests for readable, end_stream, read_byte, read, next_opcode, and failure cases