### PR TITLE
feat: stack opcodes + utils

### DIFF
--- a/bitcoin_executor/Move.lock
+++ b/bitcoin_executor/Move.lock
@@ -43,6 +43,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.48.0"
+compiler-version = "1.48.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/bitcoin_executor/sources/interpreter.move
+++ b/bitcoin_executor/sources/interpreter.move
@@ -2,10 +2,11 @@ module bitcoin_executor::interpreter;
 
 use bitcoin_executor::reader::{Self, ScriptReader};
 use bitcoin_executor::stack::{Self, Stack};
+use bitcoin_executor::utils::{Self, u64_to_cscriptnum};
+use std::u64::try_as_u8;
 
 #[test_only]
 use std::unit_test::assert_eq;
-
 //=============== Opcodes =============================================
 
 /// These constants are the values of the official opcodes used on the btc wiki,
@@ -284,6 +285,8 @@ const CondSkip: u8 = 2;
 // ============= Errors ================================
 #[error]
 const EEqualVerify: vector<u8> = b"SCRIPT_ERR_EQUALVERIFY";
+#[error]
+const EInvalidStackOperation: vector<u8> = b"Invalid stack operation";
 
 public struct Interpreter has copy, drop {
     stack: Stack,
@@ -318,6 +321,12 @@ fun eval(ip: &mut Interpreter, r: ScriptReader): bool {
             ip.op_push_small_int(op);
         } else if (op == OP_DUP) {
             ip.op_dup();
+        } else if (op == OP_DROP) {
+            ip.op_drop();
+        } else if (op == OP_SWAP) {
+            ip.op_swap();
+        } else if (op == OP_SIZE) {
+            ip.op_size();
         } else if (op == OP_EQUAL) {
             ip.op_equal();
         } else if (op == OP_EQUALVERIFY) {
@@ -388,6 +397,26 @@ fun op_equal_verify(ip: &mut Interpreter) {
 fun op_dup(ip: &mut Interpreter) {
     let value = ip.stack.top();
     ip.stack.push(value)
+}
+
+fun op_drop(ip: &mut Interpreter) {
+    assert!(!ip.stack.is_empty(), EInvalidStackOperation);
+    ip.stack.pop();
+}
+
+fun op_size(ip: &mut Interpreter) {
+    assert!(!ip.stack.is_empty(), EInvalidStackOperation);
+    let top_element = ip.stack.top();
+    let size = top_element.length();
+    ip.stack.push(utils::u64_to_cscriptnum(size))
+}
+
+fun op_swap(ip: &mut Interpreter) {
+    assert!(ip.stack.size() >=2, EInvalidStackOperation);
+    let first_element = ip.stack.pop();
+    let second_element = ip.stack.pop();
+    ip.stack.push(first_element);
+    ip.stack.push(second_element);
 }
 
 #[test]
@@ -519,4 +548,56 @@ fun test_op_dup_fail() {
     let stack = stack::create();
     let mut ip = new(stack);
     ip.op_dup();
+}
+
+#[test]
+fun test_op_drop() {
+    let stack = stack::create_with_data(vector[vector[0x01]]);
+    let mut ip = new(stack);
+    ip.op_drop();
+    assert_eq!(ip.stack.get_all_values(), vector[]);
+    assert_eq!(ip.stack.size(), 0);
+}
+
+#[test, expected_failure(abort_code = EInvalidStackOperation)]
+fun test_op_drop_fail() {
+    let stack = stack::create();
+    let mut ip = new(stack);
+    ip.op_drop();
+}
+
+#[test]
+fun test_op_swap() {
+    let stack = stack::create_with_data(vector[vector[0x01], vector[0x02]]);
+    let mut ip = new(stack);
+    ip.op_swap();
+    assert_eq!(ip.stack.size(), 2);
+    assert_eq!(ip.stack.get_all_values(), vector[vector[0x02], vector[0x01]]);
+}
+
+#[test, expected_failure(abort_code = EInvalidStackOperation)]
+fun test_op_swap_fail() {
+    let stack = stack::create_with_data(vector[vector[0x01]]);
+    let mut ip = new(stack);
+    ip.op_swap();
+}
+
+#[test]
+fun test_op_size() {
+    let stack = stack::create_with_data(vector[vector[0x01], vector[0x01, 0x02, 0x03]]); // top element size = 3
+    let mut ip = new(stack);
+    ip.op_size();
+    assert_eq!(ip.stack.size(), 3);
+    assert_eq!(
+        ip.stack.get_all_values(),
+        vector[vector[0x01], vector[0x01, 0x02, 0x03], vector[0x03]],
+    );
+    assert_eq!(ip.stack.top(), vector[0x03]);
+}
+
+#[test, expected_failure(abort_code = EInvalidStackOperation)]
+fun test_op_size_fail() {
+    let stack = stack::create();
+    let mut ip = new(stack);
+    ip.op_size();
 }

--- a/bitcoin_executor/sources/interpreter.move
+++ b/bitcoin_executor/sources/interpreter.move
@@ -399,12 +399,10 @@ fun op_dup(ip: &mut Interpreter) {
 }
 
 fun op_drop(ip: &mut Interpreter) {
-    assert!(!ip.stack.is_empty(), EInvalidStackOperation);
     ip.stack.pop();
 }
 
 fun op_size(ip: &mut Interpreter) {
-    assert!(!ip.stack.is_empty(), EInvalidStackOperation);
     let top_element = ip.stack.top();
     let size = top_element.length();
     ip.stack.push(utils::u64_to_cscriptnum(size))
@@ -558,7 +556,7 @@ fun test_op_drop() {
     assert_eq!(ip.stack.size(), 0);
 }
 
-#[test, expected_failure(abort_code = EInvalidStackOperation)]
+#[test, expected_failure(abort_code = stack::EPopStackEmpty)]
 fun test_op_drop_fail() {
     let stack = stack::create();
     let mut ip = new(stack);
@@ -594,7 +592,7 @@ fun test_op_size() {
     assert_eq!(ip.stack.top(), vector[0x03]);
 }
 
-#[test, expected_failure(abort_code = EInvalidStackOperation)]
+#[test, expected_failure(abort_code = stack::EPopStackEmpty)]
 fun test_op_size_fail() {
     let stack = stack::create();
     let mut ip = new(stack);

--- a/bitcoin_executor/sources/interpreter.move
+++ b/bitcoin_executor/sources/interpreter.move
@@ -2,8 +2,7 @@ module bitcoin_executor::interpreter;
 
 use bitcoin_executor::reader::{Self, ScriptReader};
 use bitcoin_executor::stack::{Self, Stack};
-use bitcoin_executor::utils::{Self, u64_to_cscriptnum};
-use std::u64::try_as_u8;
+use bitcoin_executor::utils;
 
 #[test_only]
 use std::unit_test::assert_eq;

--- a/bitcoin_executor/sources/utils.move
+++ b/bitcoin_executor/sources/utils.move
@@ -1,0 +1,42 @@
+module bitcoin_executor::utils;
+
+#[test_only]
+use std::unit_test::assert_eq;
+
+/// Converts u64 into the CScriptNum byte vector format.
+/// This is the format expected to be pushed onto the stack.
+/// https://github.com/bitcoin/bitcoin/blob/87ec923d3a7af7b30613174b41c6fb11671df466/src/script/script.h#L349
+public(package) fun u64_to_cscriptnum(n: u64): vector<u8> {
+    if (n == 0) {
+        return vector[] // 0 is represented by empty vector
+    };
+
+    let mut temp_n = n;
+    let mut result_bytes = vector::empty<u8>();
+
+    // convert to little endian
+    while (temp_n > 0) {
+        vector::push_back(&mut result_bytes, (temp_n & 0xff) as u8);
+        temp_n = temp_n >> 8;
+    };
+
+    // padding
+    if (vector::length(&result_bytes) > 0) {
+        let last_byte_index = vector::length(&result_bytes) - 1;
+        let last_byte = *vector::borrow(&result_bytes, last_byte_index);
+        if ((last_byte & 0x80) != 0) {
+            vector::push_back(&mut result_bytes, 0x00);
+        }
+    };
+    result_bytes
+}
+
+#[test]
+fun test_u64_to_cscriptnum() {
+    assert_eq!(u64_to_cscriptnum(0), vector[]); // 0 -> []
+    assert_eq!(u64_to_cscriptnum(127), vector[0x7f]); // 127 -> [0x7f]
+    assert_eq!(u64_to_cscriptnum(128), vector[0x80, 0x00]); // 128 -> [0x80, 0x00] padding
+    assert_eq!(u64_to_cscriptnum(255), vector[0xff, 0x00]); // 255 -> [0xff, 0x00] padding
+    assert_eq!(u64_to_cscriptnum(256), vector[0x00, 0x01]); // 256 -> [0x00, 0x01]
+    assert_eq!(u64_to_cscriptnum(520), vector[0x08, 0x02]); // 520 -> [0x08, 0x02]
+}

--- a/bitcoin_executor/sources/utils.move
+++ b/bitcoin_executor/sources/utils.move
@@ -15,14 +15,14 @@ public(package) fun u64_to_cscriptnum(n: u64): vector<u8> {
     let mut n = n;
     // convert to little endian
     while (n > 0) {
-        vector::push_back(&mut result_bytes, (n & 0xff) as u8);
+        result_bytes.push_back((n & 0xff) as u8);
         n = n >> 8;
     };
 
     // padding
     if (result_bytes.length() > 0) {
-        let last_byte_index = vector::length(&result_bytes) - 1;
-        let last_byte = *vector::borrow(&result_bytes, last_byte_index);
+        let last_index = result_bytes.length() -1;
+        let last_byte = *result_bytes.borrow(last_index);
         if ((last_byte & 0x80) != 0) {
             result_bytes.push_back(0x00);
         }

--- a/bitcoin_executor/sources/utils.move
+++ b/bitcoin_executor/sources/utils.move
@@ -9,15 +9,14 @@ use std::unit_test::assert_eq;
 public(package) fun u64_to_cscriptnum(n: u64): vector<u8> {
     let mut result_bytes = vector::empty<u8>();
     if (n == 0) {
-        return result_bytes// 0 is represented by empty vector
+        return result_bytes // 0 is represented by empty vector
     };
-    
-    let mut n = n;
 
+    let mut n = n;
     // convert to little endian
-    while (temp_n > 0) {
-        vector::push_back(&mut result_bytes, (temp_n & 0xff) as u8);
-        temp_n = temp_n >> 8;
+    while (n > 0) {
+        vector::push_back(&mut result_bytes, (n & 0xff) as u8);
+        n = n >> 8;
     };
 
     // padding

--- a/bitcoin_executor/sources/utils.move
+++ b/bitcoin_executor/sources/utils.move
@@ -7,12 +7,12 @@ use std::unit_test::assert_eq;
 /// This is the format expected to be pushed onto the stack.
 /// https://github.com/bitcoin/bitcoin/blob/87ec923d3a7af7b30613174b41c6fb11671df466/src/script/script.h#L349
 public(package) fun u64_to_cscriptnum(n: u64): vector<u8> {
-    if (n == 0) {
-        return vector[] // 0 is represented by empty vector
-    };
-
-    let mut temp_n = n;
     let mut result_bytes = vector::empty<u8>();
+    if (n == 0) {
+        return result_bytes// 0 is represented by empty vector
+    };
+    
+    let mut n = n;
 
     // convert to little endian
     while (temp_n > 0) {
@@ -21,11 +21,11 @@ public(package) fun u64_to_cscriptnum(n: u64): vector<u8> {
     };
 
     // padding
-    if (vector::length(&result_bytes) > 0) {
+    if (result_bytes.length() > 0) {
         let last_byte_index = vector::length(&result_bytes) - 1;
         let last_byte = *vector::borrow(&result_bytes, last_byte_index);
         if ((last_byte & 0x80) != 0) {
-            vector::push_back(&mut result_bytes, 0x00);
+            result_bytes.push_back(0x00);
         }
     };
     result_bytes


### PR DESCRIPTION
## Summary by Sourcery

Implement new stack manipulation opcodes (DROP, SWAP, SIZE) with proper error handling, introduce a utility for CScript number encoding, and add comprehensive tests for these features

New Features:
- Support OP_DROP, OP_SWAP, and OP_SIZE opcodes in the Bitcoin script interpreter
- Introduce a u64_to_cscriptnum utility for converting integers to CScript number format

Enhancements:
- Add EInvalidStackOperation error for invalid stack operations

Tests:
- Add unit tests for OP_DROP, OP_SWAP, OP_SIZE, and u64_to_cscriptnum, including success and failure cases