### PR TITLE
feat: add utxo set

### DIFF
--- a/bitcoin_executor/sources/node.move
+++ b/bitcoin_executor/sources/node.move
@@ -1,7 +1,7 @@
 module bitcoin_executor::bitcoin_executor;
 
 use bitcoin_executor::tx::{Self, Transaction};
-use bitcoin_executor::utxo::{Self, OutPoint, Info};
+use bitcoin_executor::utxo::{Self, OutPoint, Data};
 use std::unit_test::assert_eq;
 use sui::table::{Self, Table};
 
@@ -12,7 +12,7 @@ const ECoinbaseNotMature: vector<u8> =
 fun init(ctx: &mut TxContext) {
     let state = State {
         id: object::new(ctx),
-        utxos: table::new<OutPoint, Info>(ctx),
+        utxos: table::new<OutPoint, Data>(ctx),
     };
     transfer::share_object(state);
 }
@@ -25,7 +25,7 @@ public struct Block has copy, drop {
 /// State stores the utxo set
 public struct State has key, store {
     id: UID,
-    utxos: Table<OutPoint, Info>,
+    utxos: Table<OutPoint, Data>,
 }
 
 fun store(_state: &mut State, _block: &Block) {}
@@ -46,12 +46,12 @@ public fun executeBlock(state: &mut State, block: &Block): bool {
 }
 
 /// Adds a new UTXO to the set
-public fun add_utxo(state: &mut State, outpoint: OutPoint, info: Info) {
+public fun add_utxo(state: &mut State, outpoint: OutPoint, info: Data) {
     state.utxos.add(outpoint, info);
 }
 
 /// Spends a UTXO checks for existence and coinbase maturity, removes it, and returns its Info
-public fun spend_utxo(state: &mut State, outpoint: OutPoint, current_block_height: u64): Info {
+public fun spend_utxo(state: &mut State, outpoint: OutPoint, current_block_height: u64): Data {
     let utxo_info = state.utxos.borrow(outpoint);
 
     if (utxo_info.is_coinbase()) {
@@ -73,7 +73,7 @@ fun test_add_utxo() {
 
     let mut state = State {
         id: object::new(&mut ctx),
-        utxos: table::new<OutPoint, Info>(&mut ctx),
+        utxos: table::new<OutPoint, Data>(&mut ctx),
     };
     add_utxo(&mut state, outpint, info);
     assert_eq!(state.utxos.length(), 1);
@@ -89,7 +89,7 @@ fun test_add_utxo_fail() {
 
     let mut state = State {
         id: object::new(&mut ctx),
-        utxos: table::new<OutPoint, Info>(&mut ctx),
+        utxos: table::new<OutPoint, Data>(&mut ctx),
     };
     add_utxo(&mut state, outpint, info);
     add_utxo(&mut state, outpint, info);
@@ -104,7 +104,7 @@ fun test_spend_utxo() {
 
     let mut state = State {
         id: object::new(&mut ctx),
-        utxos: table::new<OutPoint, Info>(&mut ctx),
+        utxos: table::new<OutPoint, Data>(&mut ctx),
     };
     add_utxo(&mut state, outpint, info);
     spend_utxo(&mut state, outpint, 2);
@@ -120,7 +120,7 @@ fun test_spend_utxo_is_coinbase() {
 
     let mut state = State {
         id: object::new(&mut ctx),
-        utxos: table::new<OutPoint, Info>(&mut ctx),
+        utxos: table::new<OutPoint, Data>(&mut ctx),
     };
     add_utxo(&mut state, outpint, info);
     spend_utxo(&mut state, outpint, 101);
@@ -136,7 +136,7 @@ fun test_spend_utxo_is_coinbase_fail() {
 
     let mut state = State {
         id: object::new(&mut ctx),
-        utxos: table::new<OutPoint, Info>(&mut ctx),
+        utxos: table::new<OutPoint, Data>(&mut ctx),
     };
     add_utxo(&mut state, outpint, info);
     spend_utxo(&mut state, outpint, 101);

--- a/bitcoin_executor/sources/node.move
+++ b/bitcoin_executor/sources/node.move
@@ -7,7 +7,7 @@ use sui::table::{Self, Table};
 
 #[error]
 const ECoinbaseNotMature: vector<u8> =
-    b"Coinbase tx is not spendable until it reaches maturnity of 100 blocks";
+    b"Coinbase tx is not spendable until it reaches maturity of 100 blocks";
 
 fun init(ctx: &mut TxContext) {
     let state = State {

--- a/bitcoin_executor/sources/node.move
+++ b/bitcoin_executor/sources/node.move
@@ -1,24 +1,36 @@
-/// Module: bitcoin_executor
 module bitcoin_executor::bitcoin_executor;
-use bitcoin_executor::tx::{Transaction, Self};
 
-fun init(_ctx: &mut tx_context::TxContext) {}
+use bitcoin_executor::tx::{Self, Transaction};
+use bitcoin_executor::utxo::{Self, OutPoint, Info};
+use std::unit_test::assert_eq;
+use sui::table::{Self, Table};
+
+#[error]
+const ECoinbaseNotMature: vector<u8> =
+    b"Coinbase tx is not spendable until it reaches maturnity of 100 blocks";
+
+fun init(ctx: &mut TxContext) {
+    let state = State {
+        id: object::new(ctx),
+        utxos: table::new<OutPoint, Info>(ctx),
+    };
+    transfer::share_object(state);
+}
 
 /// A block is a collection of all transactions in the BTC block
 public struct Block has copy, drop {
-    txns: vector<Transaction>
+    txns: vector<Transaction>,
 }
 
-/// State stores all valid BTC blocks
+/// State stores the utxo set
 public struct State has key, store {
     id: UID,
+    utxos: Table<OutPoint, Info>,
 }
 
+fun store(_state: &mut State, _block: &Block) {}
 
-fun store(_state: &mut State, _block: &Block) {
-    // TODO: Implement this.
-}
-
+// TODO: integrate it with the parser and update the utxo set
 public fun executeBlock(state: &mut State, block: &Block): bool {
     assert!(block.txns.is_empty()); // block should be empty
     assert!(block.txns[0].is_coinbase());
@@ -31,4 +43,102 @@ public fun executeBlock(state: &mut State, block: &Block): bool {
     };
     state.store(block);
     true
+}
+
+/// Adds a new UTXO to the set
+public fun add_utxo(state: &mut State, outpoint: OutPoint, info: Info) {
+    state.utxos.add(outpoint, info);
+}
+
+/// Spends a UTXO checks for existence and coinbase maturity, removes it, and returns its Info
+public fun spend_utxo(state: &mut State, outpoint: OutPoint, current_block_height: u64): Info {
+    let utxo_info = state.utxos.borrow(outpoint);
+
+    if (utxo_info.is_coinbase()) {
+        assert!(current_block_height >= utxo_info.height() + 100, ECoinbaseNotMature);
+    };
+    state.utxos.remove(outpoint)
+}
+
+/// Checks if a UTXO exists in the set
+public fun utxo_exists(state: &State, outpoint: OutPoint): bool {
+    state.utxos.contains(outpoint)
+}
+
+#[test]
+fun test_add_utxo() {
+    let mut ctx = tx_context::dummy();
+
+    let (outpint, info) = utxo::new(x"01", 1, 1, true, 1, x"01");
+
+    let mut state = State {
+        id: object::new(&mut ctx),
+        utxos: table::new<OutPoint, Info>(&mut ctx),
+    };
+    add_utxo(&mut state, outpint, info);
+    assert_eq!(state.utxos.length(), 1);
+    assert_eq!(state.utxos.contains(outpint), true);
+    transfer::public_transfer(state, @0xCAFE);
+}
+
+#[test, expected_failure(abort_code = sui::dynamic_field::EFieldAlreadyExists)]
+fun test_add_utxo_fail() {
+    let mut ctx = tx_context::dummy();
+
+    let (outpint, info) = utxo::new(x"01", 1, 1, true, 1, x"01");
+
+    let mut state = State {
+        id: object::new(&mut ctx),
+        utxos: table::new<OutPoint, Info>(&mut ctx),
+    };
+    add_utxo(&mut state, outpint, info);
+    add_utxo(&mut state, outpint, info);
+    transfer::public_transfer(state, @0xCAFE);
+}
+
+#[test]
+fun test_spend_utxo() {
+    let mut ctx = tx_context::dummy();
+
+    let (outpint, info) = utxo::new(x"01", 1, 1, false, 1, x"01");
+
+    let mut state = State {
+        id: object::new(&mut ctx),
+        utxos: table::new<OutPoint, Info>(&mut ctx),
+    };
+    add_utxo(&mut state, outpint, info);
+    spend_utxo(&mut state, outpint, 2);
+    assert_eq!(state.utxos.length(), 0);
+    transfer::public_transfer(state, @0xCAFE);
+}
+
+#[test]
+fun test_spend_utxo_is_coinbase() {
+    let mut ctx = tx_context::dummy();
+
+    let (outpint, info) = utxo::new(x"01", 1, 1, true, 1, x"01");
+
+    let mut state = State {
+        id: object::new(&mut ctx),
+        utxos: table::new<OutPoint, Info>(&mut ctx),
+    };
+    add_utxo(&mut state, outpint, info);
+    spend_utxo(&mut state, outpint, 101);
+    assert_eq!(state.utxos.length(), 0);
+    transfer::public_transfer(state, @0xCAFE);
+}
+
+#[test, expected_failure(abort_code = ECoinbaseNotMature)]
+fun test_spend_utxo_is_coinbase_fail() {
+    let mut ctx = tx_context::dummy();
+
+    let (outpint, info) = utxo::new(x"01", 1, 100, true, 1, x"01");
+
+    let mut state = State {
+        id: object::new(&mut ctx),
+        utxos: table::new<OutPoint, Info>(&mut ctx),
+    };
+    add_utxo(&mut state, outpint, info);
+    spend_utxo(&mut state, outpint, 101);
+    transfer::public_transfer(state, @0xCAFE);
 }

--- a/bitcoin_executor/sources/utxo.move
+++ b/bitcoin_executor/sources/utxo.move
@@ -1,0 +1,44 @@
+module bitcoin_executor::utxo;
+
+public struct OutPoint has copy, drop, store {
+    tx_id: vector<u8>,
+    vout: u32,
+}
+
+public struct Info has copy, drop, store {
+    height: u64, // The height of the block containing the UTXO.
+    is_coinbase: bool, // Whether the UTXO is from a coinbase transaction or not.
+    value: u64, // Amount in satoshis
+    script_pub_key: vector<u8>, // The locking script
+}
+
+public fun new_outpoint(tx_id: vector<u8>, vout: u32): OutPoint {
+    OutPoint { tx_id, vout }
+}
+
+public fun new_info(height: u64, is_coinbase: bool, value: u64, script_pub_key: vector<u8>): Info {
+    Info { height, is_coinbase, value, script_pub_key }
+}
+
+public fun new(
+    tx_id: vector<u8>,
+    vout: u32,
+    height: u64,
+    is_coinbase: bool,
+    value: u64,
+    script_pub_key: vector<u8>,
+): (OutPoint, Info) {
+    (OutPoint { tx_id, vout }, Info { height, is_coinbase, value, script_pub_key })
+}
+
+public fun tx_id(outpoint: &OutPoint): vector<u8> { outpoint.tx_id }
+
+public fun vout(outpoint: &OutPoint): u32 { outpoint.vout }
+
+public fun value(info: &Info): u64 { info.value }
+
+public fun script_pub_key(info: &Info): &vector<u8> { &info.script_pub_key }
+
+public fun height(info: &Info): u64 { info.height }
+
+public fun is_coinbase(info: &Info): bool { info.is_coinbase }

--- a/bitcoin_executor/sources/utxo.move
+++ b/bitcoin_executor/sources/utxo.move
@@ -5,7 +5,7 @@ public struct OutPoint has copy, drop, store {
     vout: u32,
 }
 
-public struct Info has copy, drop, store {
+public struct Data has copy, drop, store {
     height: u64, // The height of the block containing the UTXO.
     is_coinbase: bool, // Whether the UTXO is from a coinbase transaction or not.
     value: u64, // Amount in satoshis
@@ -16,7 +16,7 @@ public fun new_outpoint(tx_id: vector<u8>, vout: u32): OutPoint {
     OutPoint { tx_id, vout }
 }
 
-public fun new_info(height: u64, is_coinbase: bool, value: u64, script_pub_key: vector<u8>): Info {
+public fun new_data(height: u64, is_coinbase: bool, value: u64, script_pub_key: vector<u8>): Info {
     Info { height, is_coinbase, value, script_pub_key }
 }
 

--- a/bitcoin_executor/sources/utxo.move
+++ b/bitcoin_executor/sources/utxo.move
@@ -16,8 +16,8 @@ public fun new_outpoint(tx_id: vector<u8>, vout: u32): OutPoint {
     OutPoint { tx_id, vout }
 }
 
-public fun new_data(height: u64, is_coinbase: bool, value: u64, script_pub_key: vector<u8>): Info {
-    Info { height, is_coinbase, value, script_pub_key }
+public fun new_data(height: u64, is_coinbase: bool, value: u64, script_pub_key: vector<u8>): Data {
+    Data { height, is_coinbase, value, script_pub_key }
 }
 
 public fun new(
@@ -27,18 +27,18 @@ public fun new(
     is_coinbase: bool,
     value: u64,
     script_pub_key: vector<u8>,
-): (OutPoint, Info) {
-    (OutPoint { tx_id, vout }, Info { height, is_coinbase, value, script_pub_key })
+): (OutPoint, Data) {
+    (OutPoint { tx_id, vout }, Data { height, is_coinbase, value, script_pub_key })
 }
 
 public fun tx_id(outpoint: &OutPoint): vector<u8> { outpoint.tx_id }
 
 public fun vout(outpoint: &OutPoint): u32 { outpoint.vout }
 
-public fun value(info: &Info): u64 { info.value }
+public fun value(data: &Data): u64 { data.value }
 
-public fun script_pub_key(info: &Info): &vector<u8> { &info.script_pub_key }
+public fun script_pub_key(data: &Data): &vector<u8> { &data.script_pub_key }
 
-public fun height(info: &Info): u64 { info.height }
+public fun height(data: &Data): u64 { data.height }
 
-public fun is_coinbase(info: &Info): bool { info.is_coinbase }
+public fun is_coinbase(data: &Data): bool { data.is_coinbase }


### PR DESCRIPTION
## Summary by Sourcery

Implement a UTXO set in the bitcoin_executor by defining OutPoint and Info types, integrating a UTXO table into State, and adding functions to add, spend (with coinbase maturity enforcement), and query UTXOs.

New Features:
- Introduce a utxo module with OutPoint and Info structs and associated constructors and accessors
- Add add_utxo, spend_utxo (including coinbase maturity check), and utxo_exists functions to manage the UTXO set
- Incorporate a UTXO table field into State and initialize it in the module init function

Enhancements:
- Define ECoinbaseNotMature error constant for aborting on immature coinbase spends
- Update module init to create and share the UTXO-enabled State object

Tests:
- Add unit tests covering UTXO addition, duplicate insertion failure, spending, and coinbase maturity enforcement