### PR TITLE
fix(nBTC): wrong fallback address in nBTC test

### DIFF
--- a/nBTC/tests/nbtc_tests.move
+++ b/nBTC/tests/nbtc_tests.move
@@ -83,7 +83,7 @@ fun test_nbtc_mint_fallback() {
     let lock_time = x"00000000";
     let height = 0;
     let tx_index = 0;
-    let fallback_address = @0xCF;
+    let fallback_address = @fallback;
     nbtc::mint(&mut cap, &lc, version, input_count, inputs, output_count, outputs, lock_time, proof, height, tx_index, ctx);
     test_scenario::next_tx(&mut scenario, sender);
     let coin = take_from_address<Coin<NBTC>>(&scenario, fallback_address);


### PR DESCRIPTION
## Summary by Sourcery

Fix the nBTC mint fallback test by replacing the hard-coded fallback address with the actual variable reference.

Bug Fixes:
- Use the correct fallback address in the nBTC mint fallback test instead of a hard-coded address.

Tests:
- Update the test_nbtc_mint_fallback case to reference the dynamic fallback address variable.