### PR TITLE
refactor(executor): update few function names

### DIFF
--- a/bitcoin_executor/sources/interpreter.move
+++ b/bitcoin_executor/sources/interpreter.move
@@ -215,6 +215,8 @@ const OP_NOP8: u8 = 0xb7; // 183
 const OP_NOP9: u8 = 0xb8; // 184
 const OP_NOP10: u8 = 0xb9; // 185
 const OP_CHECKSIGADD: u8 = 0xba; // 186
+
+/* NOT USED
 const OP_UNKNOWN187: u8 = 0xbb; // 187
 const OP_UNKNOWN188: u8 = 0xbc; // 188
 const OP_UNKNOWN189: u8 = 0xbd; // 189
@@ -278,9 +280,13 @@ const OP_UNKNOWN246: u8 = 0xf6; // 246
 const OP_UNKNOWN247: u8 = 0xf7; // 247
 const OP_UNKNOWN248: u8 = 0xf8; // 248
 const OP_UNKNOWN249: u8 = 0xf9; // 249
+*/
+
 const OP_SMALLINTEGER: u8 = 0xfa; // 250 - bitcoin core internal
 const OP_PUBKEYS: u8 = 0xfb; // 251 - bitcoin core internal
-const OP_UNKNOWN252: u8 = 0xfc; // 252
+
+// const OP_UNKNOWN252: u8 = 0xfc; // 252
+
 const OP_PUBKEYHASH: u8 = 0xfd; // 253 - bitcoin core internal
 const OP_PUBKEY: u8 = 0xfe; // 254 - bitcoin core internal
 const OP_INVALIDOPCODE: u8 = 0xff; // 255 - bitcoin core internal
@@ -517,7 +523,7 @@ fun op_checksig(ip: &mut Interpreter) {
 
     assert!(option::is_some(&ip.tx_context), EMissingTxCtx);
 
-    let message_digest = create_sighash_dispatch(ip, pubkey_bytes, sighash_flag);
+    let message_digest = create_sighash(ip, pubkey_bytes, sighash_flag);
 
     let signature_is_valid = sui::ecdsa_k1::secp256k1_verify(
         &sig_to_verify,
@@ -533,7 +539,7 @@ fun op_checksig(ip: &mut Interpreter) {
     };
 }
 
-public fun create_p2wpkh_scriptcode_bytes(pkh: vector<u8>): vector<u8> {
+public fun create_p2wpkh_scriptcode(pkh: vector<u8>): vector<u8> {
     assert!(pkh.length() == 20, EInvalidStackOperation);
     let mut script = vector::empty<u8>();
     script.push_back(OP_DUP);
@@ -545,16 +551,16 @@ public fun create_p2wpkh_scriptcode_bytes(pkh: vector<u8>): vector<u8> {
     script
 }
 
-fun create_sighash_dispatch(ip: &Interpreter, pub_key: vector<u8>, sighash_flag: u8): vector<u8> {
+fun create_sighash(ip: &Interpreter, pub_key: vector<u8>, sighash_flag: u8): vector<u8> {
     let ctx = ip.tx_context.borrow();
     if (ctx.sig_version == SIG_VERSION_WITNESS_V0) {
         let sha = sha2_256(pub_key);
         let mut hash160 = ripemd160::new();
         hash160.write(sha, sha.length());
         let pkh = hash160.finalize();
-        let script_code_to_use_for_sighash = create_p2wpkh_scriptcode_bytes(pkh);
+        let script_code_to_use_for_sighash = create_p2wpkh_scriptcode(pkh);
 
-        let bip143_preimage = sighash::create_bip143_sighash_preimage(
+        let bip143_preimage = sighash::create_bip143_sighash(
             &ctx.tx,
             ctx.input_index,
             &script_code_to_use_for_sighash,
@@ -784,11 +790,11 @@ fun test_op_hash256() {
 }
 
 #[test]
-fun test_create_p2wpkh_scriptcode_bytes() {
+fun test_create_p2wpkh_scriptcode() {
     // data taken from https://learnmeabitcoin.com/technical/keys/signature/
     let pkh = x"aa966f56de599b4094b61aa68a2b3df9e97e9c48";
     let expected_script_code = x"76a914aa966f56de599b4094b61aa68a2b3df9e97e9c4888ac";
-    assert_eq!(create_p2wpkh_scriptcode_bytes(pkh), expected_script_code);
+    assert_eq!(create_p2wpkh_scriptcode(pkh), expected_script_code);
 }
 
 #[test]

--- a/bitcoin_executor/sources/interpreter.move
+++ b/bitcoin_executor/sources/interpreter.move
@@ -560,7 +560,7 @@ fun create_sighash(ip: &Interpreter, pub_key: vector<u8>, sighash_flag: u8): vec
         let pkh = hash160.finalize();
         let script_code_to_use_for_sighash = create_p2wpkh_scriptcode(pkh);
 
-        let bip143_preimage = sighash::create_bip143_sighash(
+        let bip143_preimage = sighash::create_segwit_preimage(
             &ctx.tx,
             ctx.input_index,
             &script_code_to_use_for_sighash,

--- a/bitcoin_executor/sources/node.move
+++ b/bitcoin_executor/sources/node.move
@@ -3,7 +3,7 @@
 module bitcoin_executor::bitcoin_executor;
 
 use bitcoin_executor::block;
-use bitcoin_executor::interpreter::{run, create_p2wpkh_scriptcode_bytes};
+use bitcoin_executor::interpreter::{run, create_p2wpkh_scriptcode};
 use bitcoin_executor::stack;
 use bitcoin_executor::tx::Transaction;
 use bitcoin_executor::utils::LEtoNumber;
@@ -106,7 +106,7 @@ fun validate_execution(state: &State, tx: Transaction): bool {
         // TODO: We only support P2WPKH now.
         // We will support more standard scripts.
         let pk = data.pkh();
-        let script = create_p2wpkh_scriptcode_bytes(pk);
+        let script = create_p2wpkh_scriptcode(pk);
         let valid = run(tx, stack, script, i, data.value());
         if (!valid) {
             result = false;

--- a/bitcoin_executor/sources/reader.move
+++ b/bitcoin_executor/sources/reader.move
@@ -4,9 +4,6 @@ module bitcoin_executor::reader;
 
 use bitcoin_executor::utils::LEtoNumber;
 
-#[error]
-const EBadOpcode: vector<u8> = b"Bad opcode";
-
 // TODO: Follow error in btc implemetation
 #[error]
 const EBadReadData: vector<u8> = b"Invalid read script";

--- a/bitcoin_executor/sources/sighash.move
+++ b/bitcoin_executor/sources/sighash.move
@@ -10,23 +10,26 @@ use bitcoin_executor::utils::{Self, hash256};
 #[test_only]
 use sui::test_utils::assert_eq;
 
+/// Sighash types
 const SIGHASH_ALL: u8 = 0x01;
 const SIGHASH_NONE: u8 = 0x02;
 const SIGHASH_SINGLE: u8 = 0x03;
 const SIGHASH_ANYONECANPAY_FLAG: u8 = 0x80;
 
-public fun create_bip143_sighash(
+/// Constructs the BIP143 preimage for the Segwit hash signature.
+/// https://learnmeabitcoin.com/technical/keys/signature/ -> Segwit Algorithm
+public fun create_segwit_preimage(
     transaction: &Transaction,
-    input_idx_being_signed: u64,
-    script_code_for_input: &vector<u8>, // For P2WPKH: 0x1976a914{PKH}88ac. For P2WSH: the witnessScript.
+    input_idx_to_sign: u64,
+    input_script: &vector<u8>, // For P2WPKH: 0x1976a914{PKH}88ac. For P2WSH: the witnessScript.
     amount_spent_by_this_input: u64,
-    sighash_type_byte: u8,
+    sighash_type: u8,
 ): vector<u8> {
     let mut preimage = vector[];
     preimage.append(transaction.version());
 
     // HASH256(concatenation of all (input.tx_id + input.vout))
-    let hash_prevouts: vector<u8> = if ((sighash_type_byte & SIGHASH_ANYONECANPAY_FLAG) == 0) {
+    let hash_prevouts: vector<u8> = if ((sighash_type & SIGHASH_ANYONECANPAY_FLAG) == 0) {
         let mut all_prevouts_concat = vector[];
         transaction.inputs().length().do!(|i| {
             let input_ref = transaction.input_at(i);
@@ -40,10 +43,10 @@ public fun create_bip143_sighash(
     preimage.append(hash_prevouts);
 
     // HASH256(concatenation of all input.sequence)
-    let base_sighash_type = sighash_type_byte & 0x1f; // Mask off ANYONECANPAY bit
+    let base_sighash_type = sighash_type & 0x1f; // Mask off ANYONECANPAY bit
 
     let hash_sequence = if (
-        (sighash_type_byte & SIGHASH_ANYONECANPAY_FLAG) == 0 &&
+        (sighash_type & SIGHASH_ANYONECANPAY_FLAG) == 0 &&
             base_sighash_type != SIGHASH_NONE &&
             base_sighash_type != SIGHASH_SINGLE
     ) {
@@ -58,11 +61,11 @@ public fun create_bip143_sighash(
     preimage.append(hash_sequence);
 
     // Serialize the TXID and VOUT for the input were signing
-    let current_input = transaction.input_at(input_idx_being_signed);
+    let current_input = transaction.input_at(input_idx_to_sign);
     preimage.append(current_input.tx_id());
     preimage.append(current_input.vout());
 
-    preimage.append(utils::script_to_var_bytes(script_code_for_input));
+    preimage.append(utils::script_to_var_bytes(input_script));
     preimage.append(utils::u64_to_le_bytes(amount_spent_by_this_input));
     preimage.append(current_input.sequence());
 
@@ -78,9 +81,9 @@ public fun create_bip143_sighash(
         });
         hash256(all_outputs_concat)
     } else if (
-        base_sighash_type == SIGHASH_SINGLE && input_idx_being_signed < transaction.outputs().length()
+        base_sighash_type == SIGHASH_SINGLE && input_idx_to_sign < transaction.outputs().length()
     ) {
-        let output_to_sign = transaction.output_at(input_idx_being_signed);
+        let output_to_sign = transaction.output_at(input_idx_to_sign);
         let mut single_output_concatenated = vector[];
         single_output_concatenated.append(output_to_sign.amount());
         single_output_concatenated.append(
@@ -92,12 +95,12 @@ public fun create_bip143_sighash(
     };
     preimage.append(hash_outputs);
     preimage.append(transaction.locktime());
-    preimage.append(utils::u32_to_le_bytes((sighash_type_byte as u32)));
+    preimage.append(utils::u32_to_le_bytes((sighash_type as u32)));
     preimage //Complete preimage data to be hashed (Once and later edcsa::verify will hash second time)
 }
 
 #[test]
-fun test_create_bip143_sighash_lmb_example() {
+fun test_create_segwit_preimage_lmb_example() {
     // all the data for the test copied from the exmaple https://learnmeabitcoin.com/technical/keys/signature/
     let expected_preimage =
         x"02000000cbfaca386d65ea7043aaac40302325d0dc7391a73b585571e28d3287d6b162033bb13029ce7b1f559ef5e747fcac439f1455a2ec7c5f09b72290795e70665044ac4994014aa36b7f53375658ef595b3cb2891e1735fe5b441686f5e53338e76a010000001976a914aa966f56de599b4094b61aa68a2b3df9e97e9c4888ac3075000000000000ffffffff900a6c6ff6cd938bf863e50613a4ed5fb1661b78649fe354116edaf5d4abb9520000000001000000";
@@ -131,17 +134,17 @@ fun test_create_bip143_sighash_lmb_example() {
         vector[],
     );
 
-    let input_idx_being_signed = 0u64;
-    let script_code_for_input = x"76a914aa966f56de599b4094b61aa68a2b3df9e97e9c4888ac";
+    let input_idx_to_sign = 0u64;
+    let input_script = x"76a914aa966f56de599b4094b61aa68a2b3df9e97e9c4888ac";
     let amount_spent_by_this_input = 30000u64;
-    let sighash_type_byte = SIGHASH_ALL; // 0x01
+    let sighash_type = SIGHASH_ALL; // 0x01
 
-    let result_preimage = create_bip143_sighash(
+    let result_preimage = create_segwit_preimage(
         &test_tx,
-        input_idx_being_signed,
-        &script_code_for_input,
+        input_idx_to_sign,
+        &input_script,
         amount_spent_by_this_input,
-        sighash_type_byte,
+        sighash_type,
     );
 
     assert_eq(result_preimage, expected_preimage);

--- a/bitcoin_executor/sources/sighash.move
+++ b/bitcoin_executor/sources/sighash.move
@@ -15,7 +15,7 @@ const SIGHASH_NONE: u8 = 0x02;
 const SIGHASH_SINGLE: u8 = 0x03;
 const SIGHASH_ANYONECANPAY_FLAG: u8 = 0x80;
 
-public fun create_bip143_sighash_preimage(
+public fun create_bip143_sighash(
     transaction: &Transaction,
     input_idx_being_signed: u64,
     script_code_for_input: &vector<u8>, // For P2WPKH: 0x1976a914{PKH}88ac. For P2WSH: the witnessScript.
@@ -97,7 +97,7 @@ public fun create_bip143_sighash_preimage(
 }
 
 #[test]
-fun test_create_bip143_sighash_preimage_lmb_example() {
+fun test_create_bip143_sighash_lmb_example() {
     // all the data for the test copied from the exmaple https://learnmeabitcoin.com/technical/keys/signature/
     let expected_preimage =
         x"02000000cbfaca386d65ea7043aaac40302325d0dc7391a73b585571e28d3287d6b162033bb13029ce7b1f559ef5e747fcac439f1455a2ec7c5f09b72290795e70665044ac4994014aa36b7f53375658ef595b3cb2891e1735fe5b441686f5e53338e76a010000001976a914aa966f56de599b4094b61aa68a2b3df9e97e9c4888ac3075000000000000ffffffff900a6c6ff6cd938bf863e50613a4ed5fb1661b78649fe354116edaf5d4abb9520000000001000000";
@@ -136,7 +136,7 @@ fun test_create_bip143_sighash_preimage_lmb_example() {
     let amount_spent_by_this_input = 30000u64;
     let sighash_type_byte = SIGHASH_ALL; // 0x01
 
-    let result_preimage = create_bip143_sighash_preimage(
+    let result_preimage = create_bip143_sighash(
         &test_tx,
         input_idx_being_signed,
         &script_code_for_input,

--- a/bitcoin_executor/tests/interpreter_tests.move
+++ b/bitcoin_executor/tests/interpreter_tests.move
@@ -1,6 +1,6 @@
 #[test_only]
 module bitcoin_executor::interpreter_tests;
-use bitcoin_executor::interpreter::{create_p2wpkh_scriptcode_bytes, run};
+use bitcoin_executor::interpreter::{create_p2wpkh_scriptcode, run};
 use bitcoin_executor::tx::deserialize;
 use bitcoin_executor::reader;
 use bitcoin_executor::stack::create_with_data;
@@ -14,7 +14,7 @@ fun run_segwit_script() {
     let index = 0;
     let stack = create_with_data(tx.witness()[0].items());
     let pk = x"5c2dc82f606be66506b7403f9b304f5e0908b652";
-    let script = create_p2wpkh_scriptcode_bytes(pk);
+    let script = create_p2wpkh_scriptcode(pk);
     let ans = run(tx, stack, script, index, amount);
     assert!(ans)
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor function names for script code and sighash creation, update references and tests accordingly, comment out unused opcodes, and clean up unused error constant

Enhancements:
- Rename create_p2wpkh_scriptcode_bytes to create_p2wpkh_scriptcode and update its usages
- Rename create_sighash_dispatch to create_sighash and update its usages
- Rename create_bip143_sighash_preimage to create_bip143_sighash and update its usages and tests
- Comment out unused opcode constants in the interpreter module
- Remove unused EBadOpcode error constant from the reader module