### PR TITLE
feat(nBTC): Add one-time treasury setup

### DIFF
--- a/nBTC/Move.lock
+++ b/nBTC/Move.lock
@@ -2,12 +2,11 @@
 
 [move]
 version = 3
-manifest_digest = "E2FD333990C26BFCC7A9DB3C56018575CAB6A997E29E25B39B70367972FA8531"
-deps_digest = "52B406A7A21811BEF51751CF88DA0E76DAEFFEAC888D4F4060B1A72BBE7D8D35"
+manifest_digest = "0460E2FEE26FB825D94B990F4D999BDAFA739E060A789050B13F32FDC245DF8F"
+deps_digest = "397E6A9F7A624706DBDFEE056CE88391A15876868FD18A88504DA74EB458D697"
 dependencies = [
   { id = "BitcoinSPV", name = "BitcoinSPV" },
   { id = "Bridge", name = "Bridge" },
-  { id = "DeepBook", name = "DeepBook" },
   { id = "MoveStdlib", name = "MoveStdlib" },
   { id = "Sui", name = "Sui" },
   { id = "SuiSystem", name = "SuiSystem" },
@@ -15,7 +14,7 @@ dependencies = [
 
 [[move.package]]
 id = "BitcoinSPV"
-source = { git = "https://github.com/gonative-cc/move-bitcoin-spv.git", rev = "v0.3.0", subdir = "./" }
+source = { git = "https://github.com/gonative-cc/move-bitcoin-spv.git", rev = "release/alpha", subdir = "./" }
 
 dependencies = [
   { id = "Sui", name = "Sui" },
@@ -23,7 +22,7 @@ dependencies = [
 
 [[move.package]]
 id = "Bridge"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "04f11afaf5e0", subdir = "crates/sui-framework/packages/bridge" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "e54b798790ed", subdir = "crates/sui-framework/packages/bridge" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -32,21 +31,12 @@ dependencies = [
 ]
 
 [[move.package]]
-id = "DeepBook"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "04f11afaf5e0", subdir = "crates/sui-framework/packages/deepbook" }
-
-dependencies = [
-  { id = "MoveStdlib", name = "MoveStdlib" },
-  { id = "Sui", name = "Sui" },
-]
-
-[[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "04f11afaf5e0", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "e54b798790ed", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "04f11afaf5e0", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "e54b798790ed", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -54,7 +44,7 @@ dependencies = [
 
 [[move.package]]
 id = "SuiSystem"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "04f11afaf5e0", subdir = "crates/sui-framework/packages/sui-system" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "e54b798790ed", subdir = "crates/sui-framework/packages/sui-system" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -62,6 +52,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.46.0"
+compiler-version = "1.51.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/nBTC/Move.toml
+++ b/nBTC/Move.toml
@@ -20,8 +20,6 @@ BitcoinSPV = { git = "https://github.com/gonative-cc/move-bitcoin-spv.git", subd
 
 [addresses]
 nbtc = "0x0"
-light_client = "0x"
-fallback = "0x"
 
 # Named addresses will be accessible in Move as `@name`. They're also exported:
 # for example, `std = "0x1"` is exported by the Standard Library.

--- a/nBTC/Move.toml
+++ b/nBTC/Move.toml
@@ -5,7 +5,7 @@ license = "MPL-2.0"
 authors = ["Native"]
 
 [dependencies]
-BitcoinSPV = { git = "https://github.com/gonative-cc/move-bitcoin-spv.git", subdir = "./", rev = "v0.3.0" }
+BitcoinSPV = { git = "https://github.com/gonative-cc/move-bitcoin-spv.git", subdir = "./", rev = "release/alpha" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/nBTC/README.md
+++ b/nBTC/README.md
@@ -8,6 +8,7 @@ It's the first ever synthetic BTC that is
 - custody-less,
 - keeps the true Web3 ethos.
 - rightmost trust minimized (read about [nBTC trust model](https://x.com/goNativeCC/status/1899487861939806641))
+- NBTC_BITCOIN_PKH = 0xce9f3ad7d227c66e9744d052821c20d18a2ea78f
 
 ## Deployed contracts
 
@@ -125,3 +126,4 @@ sui client call --package 0x5419f6e223f18a9141e91a42286f2783eee27bf2667422c2100a
             51 \
     --gas-budget 100000000
 ```
+

--- a/nBTC/README.md
+++ b/nBTC/README.md
@@ -11,6 +11,9 @@ It's the first ever synthetic BTC that is
 - NBTC_BITCOIN_PKH = 0xce9f3ad7d227c66e9744d052821c20d18a2ea78f. Corresponds to `tb1qe60n447jylrxa96y6pfgy8pq6x9zafu09ky7cq` address on Bitcoin testnet.
 
 
+## Deployment 
+We need to run PTB with 2 transactions: publish nbtc + move call for setup method.
+
 ## Deployed contracts
 
 See the main [README](../README.md#deployed-objects--packages) file.

--- a/nBTC/README.md
+++ b/nBTC/README.md
@@ -8,7 +8,8 @@ It's the first ever synthetic BTC that is
 - custody-less,
 - keeps the true Web3 ethos.
 - rightmost trust minimized (read about [nBTC trust model](https://x.com/goNativeCC/status/1899487861939806641))
-- NBTC_BITCOIN_PKH = 0xce9f3ad7d227c66e9744d052821c20d18a2ea78f
+- NBTC_BITCOIN_PKH = 0xce9f3ad7d227c66e9744d052821c20d18a2ea78f. Corresponds to `tb1qe60n447jylrxa96y6pfgy8pq6x9zafu09ky7cq` address on Bitcoin testnet.
+
 
 ## Deployed contracts
 

--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -215,9 +215,6 @@ public fun get_fallback_addr(treasury: &WrappedTreasuryCap): address {
 
 #[test_only]
 public(package) fun init_for_testing(
-    btc_lc_addr: address,
-    fallback_addr: address,
-    nbtc_bitcoin_pkh: vector<u8>,
     ctx: &mut TxContext,
 ): WrappedTreasuryCap {
     let witness = NBTC {};
@@ -231,7 +228,7 @@ public(package) fun init_for_testing(
         ctx,
     );
     transfer::public_freeze_object(metadata);
-    let mut treasury = WrappedTreasuryCap {
+    let treasury = WrappedTreasuryCap {
         id: object::new(ctx),
         version: VERSION,
         cap: treasury_cap,
@@ -240,7 +237,5 @@ public(package) fun init_for_testing(
         fallback_addr: option::none(),
         nbtc_bitcoin_pkh: option::none(),
     };
-
-    treasury.setup(btc_lc_addr, fallback_addr, nbtc_bitcoin_pkh);
     treasury
 }

--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -101,7 +101,7 @@ fun init(witness: NBTC, ctx: &mut TxContext) {
 // Public functions
 //
 
-
+/// Setup the spv light client, fallback_addr and btc public key hash for treasury
 public fun setup(
     treasury: &mut WrappedTreasuryCap,
     trusted_lc_addr: address,

--- a/nBTC/tests/nbtc_tests.move
+++ b/nBTC/tests/nbtc_tests.move
@@ -40,9 +40,10 @@ fun new_lc_for_test(ctx: &mut TxContext): LightClient {
 }
 
 #[test_only]
-fun init_nbtc(ctx: &mut TxContext): (LightClient, WrappedTreasuryCap) {
+fun init_nbtc(btc_treasury: vector<u8>, ctx: &mut TxContext): (LightClient, WrappedTreasuryCap) {
     let lc = new_lc_for_test(ctx);
-    let cap = nbtc::init_for_testing(ctx);
+    let mut cap = nbtc::init_for_testing(ctx);
+    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
     (lc, cap)
 }
 
@@ -52,8 +53,7 @@ fun test_nbtc_mint() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
-    let (lc, mut cap) = init_nbtc(ctx);
-    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
 
     let proof = vector[x"52ee354a603838a57543e4f13619dfc6f9c8bc86cda7c0151466a16cefb09f6c"];
     let version = x"01000000";
@@ -99,8 +99,7 @@ fun test_nbtc_mint_fallback() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
-    let (lc, mut cap) = init_nbtc(ctx);
-    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
 
     let proof = vector[x"176a70bb168bcc72332f679689e32ca3810cdbb36d2b9d2d5a1a9a14927a42ab"];
     let version = x"01000000";
@@ -114,7 +113,7 @@ fun test_nbtc_mint_fallback() {
     let lock_time = x"00000000";
     let height = 0;
     let tx_index = 0;
-    let fallback_address = @fallback;
+    let fallback_address = FALLBACK_ADDR;
     nbtc::mint(
         &mut cap,
         &lc,
@@ -146,8 +145,7 @@ fun test_nbtc_mint_fail_amount_is_zero() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4ff"; // modified address
-    let (lc, mut cap) = init_nbtc(ctx);
-    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
 
     let proof = vector[x"52ee354a603838a57543e4f13619dfc6f9c8bc86cda7c0151466a16cefb09f6c"];
     let version = x"01000000";
@@ -186,8 +184,7 @@ fun test_nbtc_mint_fail_tx_already_used() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
-    let (lc, mut cap) = init_nbtc(ctx);
-    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
 
     let proof = vector[x"52ee354a603838a57543e4f13619dfc6f9c8bc86cda7c0151466a16cefb09f6c"];
     let version = x"01000000";
@@ -241,8 +238,7 @@ fun test_update_version_fail() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
-    let (lc, mut cap) = init_nbtc(ctx);
-    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
     nbtc::update_version(&mut cap);
     sui::test_utils::destroy(lc);
     sui::test_utils::destroy(cap);
@@ -255,9 +251,7 @@ fun test_re_setup_treasury_should_fail() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
-    let (lc, mut cap) = init_nbtc(ctx);
-    // first setup
-    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
     // resetup, should fail
     cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
 

--- a/nBTC/tests/nbtc_tests.move
+++ b/nBTC/tests/nbtc_tests.move
@@ -3,16 +3,9 @@
 #[test_only]
 module nbtc::nbtc_tests;
 
-// Configuration
-/// The Object ID of the Bitcoin SPV Light Client.
-const LIGHT_CLIENT_ID: address = @light_client;
-/// The fallback Sui address to receive nBTC if OP_RETURN data is invalid or missing.
-const FALLBACK_ADDR: address = @fallback;
-// TODO: convert to pub key hash
-/// The Bitcoin public key hash where users must send BTC to mint nBTC.
-/// Corresponds to `tb1qe60n447jylrxa96y6pfgy8pq6x9zafu09ky7cq` address on Bitcoin testnet.
-const NBTC_BITCOIN_PKH: vector<u8> = x"ce9f3ad7d227c66e9744d052821c20d18a2ea78f";
-
+// The fallback Sui address to receive nBTC if OP_RETURN data is invalid or missing.
+// Use for test
+const FALLBACK_ADDR: address = @0xB0B;
 
 use bitcoin_spv::light_client::{new_light_client, LightClient};
 use bitcoin_spv::params;

--- a/nBTC/tests/nbtc_tests.move
+++ b/nBTC/tests/nbtc_tests.move
@@ -3,6 +3,17 @@
 #[test_only]
 module nbtc::nbtc_tests;
 
+// Configuration
+/// The Object ID of the Bitcoin SPV Light Client.
+const LIGHT_CLIENT_ID: address = @light_client;
+/// The fallback Sui address to receive nBTC if OP_RETURN data is invalid or missing.
+const FALLBACK_ADDR: address = @fallback;
+// TODO: convert to pub key hash
+/// The Bitcoin public key hash where users must send BTC to mint nBTC.
+/// Corresponds to `tb1qe60n447jylrxa96y6pfgy8pq6x9zafu09ky7cq` address on Bitcoin testnet.
+const NBTC_BITCOIN_PKH: vector<u8> = x"ce9f3ad7d227c66e9744d052821c20d18a2ea78f";
+
+
 use bitcoin_spv::light_client::{new_light_client, LightClient};
 use bitcoin_spv::params;
 use nbtc::nbtc::{
@@ -38,8 +49,8 @@ fun new_lc_for_test(ctx: &mut TxContext): LightClient {
 #[test_only]
 fun init_nbtc(btc_treasury: vector<u8>, ctx: &mut TxContext): (LightClient, WrappedTreasuryCap) {
     let lc = new_lc_for_test(ctx);
-    let lc_id = lc.client_id().uid_to_inner();
-    let cap = nbtc::init_for_testing(lc_id, btc_treasury, ctx);
+    let lc_addr = lc.client_id().to_address();
+    let cap = nbtc::init_for_testing(lc_addr, FALLBACK_ADDR, btc_treasury, ctx);
     (lc, cap)
 }
 

--- a/nBTC/tests/nbtc_tests.move
+++ b/nBTC/tests/nbtc_tests.move
@@ -47,10 +47,9 @@ fun new_lc_for_test(ctx: &mut TxContext): LightClient {
 }
 
 #[test_only]
-fun init_nbtc(btc_treasury: vector<u8>, ctx: &mut TxContext): (LightClient, WrappedTreasuryCap) {
+fun init_nbtc(ctx: &mut TxContext): (LightClient, WrappedTreasuryCap) {
     let lc = new_lc_for_test(ctx);
-    let lc_addr = lc.client_id().to_address();
-    let cap = nbtc::init_for_testing(lc_addr, FALLBACK_ADDR, btc_treasury, ctx);
+    let cap = nbtc::init_for_testing(ctx);
     (lc, cap)
 }
 
@@ -60,7 +59,9 @@ fun test_nbtc_mint() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
-    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
+    let (lc, mut cap) = init_nbtc(ctx);
+    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+
     let proof = vector[x"52ee354a603838a57543e4f13619dfc6f9c8bc86cda7c0151466a16cefb09f6c"];
     let version = x"01000000";
     let input_count = 1;
@@ -105,7 +106,9 @@ fun test_nbtc_mint_fallback() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
-    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
+    let (lc, mut cap) = init_nbtc(ctx);
+    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+
     let proof = vector[x"176a70bb168bcc72332f679689e32ca3810cdbb36d2b9d2d5a1a9a14927a42ab"];
     let version = x"01000000";
     let input_count = 1;
@@ -150,7 +153,9 @@ fun test_nbtc_mint_fail_amount_is_zero() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4ff"; // modified address
-    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
+    let (lc, mut cap) = init_nbtc(ctx);
+    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+
     let proof = vector[x"52ee354a603838a57543e4f13619dfc6f9c8bc86cda7c0151466a16cefb09f6c"];
     let version = x"01000000";
     let input_count = 1;
@@ -188,7 +193,9 @@ fun test_nbtc_mint_fail_tx_already_used() {
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
-    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
+    let (lc, mut cap) = init_nbtc(ctx);
+    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+
     let proof = vector[x"52ee354a603838a57543e4f13619dfc6f9c8bc86cda7c0151466a16cefb09f6c"];
     let version = x"01000000";
     let input_count = 1;
@@ -235,16 +242,31 @@ fun test_nbtc_mint_fail_tx_already_used() {
     scenario.end();
 }
 
-#[test]
-#[expected_failure(abort_code = EAlreadyUpdated)]
+#[test, expected_failure(abort_code = EAlreadyUpdated)]
 fun test_update_version_fail() {
     let sender = @0x01;
     let mut scenario = test_scenario::begin(sender);
     let ctx = scenario.ctx();
     let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
-    let (lc, mut cap) = init_nbtc(btc_treasury, ctx);
+    let (lc, mut cap) = init_nbtc(ctx);
+    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
     nbtc::update_version(&mut cap);
     sui::test_utils::destroy(lc);
     sui::test_utils::destroy(cap);
     scenario.end();
+}
+
+#[test, expected_failure(abort_code = nbtc::EReSetupTreasuryNotAllow)]
+fun test_re_setup_treasury_should_fail() {
+    let sender = @0x01;
+    let mut scenario = test_scenario::begin(sender);
+    let ctx = scenario.ctx();
+    let btc_treasury = x"509a651dd392e1bc125323f629b67d65cca3d4bb";
+    let (lc, mut cap) = init_nbtc(ctx);
+    // first setup
+    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+    // resetup, should fail
+    cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
+
+    abort
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD012 -->

## Description

Closes: #14 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
    <!-- * `feat`: A new feature
    * `fix`: A bug fix
    * `docs`: Documentation only changes
    * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
    * `refactor`: A code change that neither fixes a bug nor adds a feature
    * `perf`: A code change that improves performance
    * `test`: Adding missing tests or correcting existing tests
    * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
    * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
    * `chore`: Other changes that don't modify src or test files
    * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Implement one-time treasury configuration via a new `setup` method and migrate core logic, tests, and documentation to use the new option-based fields.

New Features:
- Add `setup` function to configure treasury with SPV light client address, fallback address, and Bitcoin public key hash

Enhancements:
- Store treasury configuration fields as options and enforce one-time setup
- Refactor mint logic and getters to use new option-based fields

Build:
- Upgrade BitcoinSPV dependency to `release/alpha` in Move.toml

Documentation:
- Document NBTC_BITCOIN_PKH value and add deployment instructions in README

Tests:
- Update tests to call `setup` before mint operations and add test to ensure re-setup fails

Chores:
- Remove hardcoded configuration constants and named addresses for light client and fallback
- Simplify `init_for_testing` signature by removing parameters