### PR TITLE
feat: Add BTC output script parsing

### DIFF
--- a/btc_parser/.prettierrc
+++ b/btc_parser/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "printWidth": 100,
+    "wrapComments": false,
+    "useModuleLabel": true,
+    "autoGroupImports": "module",
+    "tabWidth": 4
+}

--- a/btc_parser/Move.lock
+++ b/btc_parser/Move.lock
@@ -43,6 +43,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.48.0"
+compiler-version = "1.51.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/btc_parser/sources/output.move
+++ b/btc_parser/sources/output.move
@@ -1,6 +1,32 @@
 module btc_parser::output;
 
 use btc_parser::utils::u64_to_le_bytes;
+use btc_parser::utils::vector_slice;
+
+// === BTC script opcodes ===
+/// An empty array of bytes is pushed onto the stack. (This is not a no-op: an item is added to the stack.)
+const OP_0: u8 = 0x00;
+/// Duplicates the top stack item
+const OP_DUP: u8 = 0x76;
+/// Pop the top stack item and push its RIPEMD(SHA256(top item)) hash
+const OP_HASH160: u8 = 0xa9;
+/// Push the next 20 bytes as an array onto the stack
+const OP_DATA_20: u8 = 0x14;
+/// Returns success if the inputs are exactly equal, failure otherwise
+const OP_EQUALVERIFY: u8 = 0x88;
+/// https://en.bitcoin.it/wiki/OP_CHECKSIG pushing 1/0 for success/failure
+const OP_CHECKSIG: u8 = 0xac;
+/// nulldata script
+const OP_RETURN: u8 = 0x6a;
+/// Read the next 4 bytes as N. Push the next N bytes as an array onto the stack.
+const OP_PUSHDATA4: u8 = 0x4e;
+/// Read the next 2 bytes as N. Push the next N bytes as an array onto the stack.
+const OP_PUSHDATA2: u8 = 0x4d;
+/// Read the next byte as N. Push the next N bytes as an array onto the stack.
+const OP_PUSHDATA1: u8 = 0x4c;
+/// Push the next 75 bytes onto the stack.
+const OP_DATA_75: u8 = 0x4b;
+
 
 /// Output in btc transaction
 public struct Output has copy, drop, store {
@@ -26,4 +52,74 @@ public fun amount(output: &Output): u64 {
 
 public fun script_pubkey(output: &Output): vector<u8> {
     output.script_pubkey
+}
+
+public fun is_P2PHK(output: &Output): bool {
+    let script = output.script_pubkey();
+
+    script.length() == 25 &&
+		script[0] == OP_DUP &&
+		script[1] == OP_HASH160 &&
+		script[2] == OP_DATA_20 &&
+		script[23] == OP_EQUALVERIFY &&
+		script[24] == OP_CHECKSIG
+}
+
+public fun is_op_return(output: &Output): bool {
+    let script = output.script_pubkey;
+    script.length() > 0 && script[0] == OP_RETURN
+}
+
+public fun is_P2WPHK(output: &Output): bool {
+    let script = output.script_pubkey;
+    script.length() == 22 &&
+        script[0] == OP_0 &&
+        script[1] == OP_DATA_20
+}
+
+// TODO: add support script addresses.
+// TODO: check and verify the address to make sure we support it. Return error otherwise
+/// extract pkh from the output in P2PHK or P2WPKH
+/// return empty if the cannot extract public key hash
+public fun extract_public_key_hash(output: &Output): vector<u8> {
+    let script = output.script_pubkey;
+    if (output.is_P2PHK()) {
+        return vector_slice(&script, 3, 23)
+    } else if (output.is_P2WPHK()) {
+        return vector_slice(&script, 2, 22)
+    };
+    vector[]
+}
+
+/// Extracts the data payload from an OP_RETURN output in a transaction.
+/// script = OP_RETURN <data>.
+/// If transaction mined to BTC, then this must pass basic conditions
+/// include the conditions for OP_RETURN script.
+/// This why we only return the message without check size message.
+public fun op_return(output: &Output): vector<u8> {
+    let script = output.script_pubkey;
+
+    if (script.length() == 1) {
+        return vector[]
+    };
+
+    // TODO: better document here. maybe use some ascii chart
+    if (script[1] <= OP_DATA_75) {
+        // script = OP_RETURN OP_DATA_<len> DATA
+        //          |      2 bytes         |  the rest |
+        return vector_slice(&script, 2, script.length())
+    };
+    if (script[1] == OP_PUSHDATA1) {
+        // script = OP_RETURN OP_PUSHDATA1 <1 bytes>    DATA
+        //          |      4 bytes                  |  the rest |
+        return vector_slice(&script, 3, script.length())
+    };
+    if (script[1] == OP_PUSHDATA2) {
+        // script = OP_RETURN OP_PUSHDATA2 <2 bytes>   DATA
+        //          |      4 bytes                  |  the rest |
+        return vector_slice(&script, 4, script.length())
+    };
+    // script = OP_RETURN OP_PUSHDATA4 <4-bytes> DATA
+    //          |      6 bytes                  |  the rest |
+    vector_slice(&script, 6, script.length())
 }

--- a/btc_parser/sources/output.move
+++ b/btc_parser/sources/output.move
@@ -79,8 +79,8 @@ public fun is_P2WPHK(output: &Output): bool {
 
 // TODO: add support script addresses.
 // TODO: check and verify the address to make sure we support it. Return error otherwise
-/// extract pkh from the output in P2PHK or P2WPKH
-/// return empty if the cannot extract public key hash
+/// extracts public key hash (PKH) from the output in P2PHK or P2WPKH
+/// returns an empty vector in case it was not able to extract it
 public fun extract_public_key_hash(output: &Output): vector<u8> {
     let script = output.script_pubkey;
     if (output.is_P2PHK()) {
@@ -93,9 +93,9 @@ public fun extract_public_key_hash(output: &Output): vector<u8> {
 
 /// Extracts the data payload from an OP_RETURN output in a transaction.
 /// script = OP_RETURN <data>.
-/// If transaction mined to BTC, then this must pass basic conditions
-/// include the conditions for OP_RETURN script.
-/// This why we only return the message without check size message.
+/// If transaction is mined, then this must pass basic conditions
+/// including the conditions for OP_RETURN script.
+/// This is why we only return the message without check size message.
 public fun op_return(output: &Output): vector<u8> {
     let script = output.script_pubkey;
 

--- a/btc_parser/sources/utils.move
+++ b/btc_parser/sources/utils.move
@@ -78,7 +78,7 @@ public fun hash256(data: vector<u8>): vector<u8> {
 }
 
 
-/// Returns slice of a vector for a given range [start_index ,end_index].
+/// Returns slice of a vector for a given range [start_index ,end_index).
 public fun vector_slice<T: copy + drop>(
     source: &vector<T>,
     start_index: u64,

--- a/btc_parser/tests/output_tests.move
+++ b/btc_parser/tests/output_tests.move
@@ -1,0 +1,44 @@
+#[test_only]
+module btc_parser::output_tests;
+
+use btc_parser::output;
+use std::unit_test::assert_eq;
+
+
+#[test]
+fun pkh_script_happy_cases() {
+    let output = &output::new(100, x"76a91455ae51684c43435da751ac8d2173b2652eb6410588ac");
+    assert_eq!(output.is_P2PHK(), true);
+    assert_eq!(output.extract_public_key_hash(), x"55ae51684c43435da751ac8d2173b2652eb64105");
+    let output = &output::new(10, x"79a9140fef69f3ac0d9d0473a318ae508875ad0eae3dcc88ac");
+    assert_eq!(output.is_P2PHK(), false);
+    let output = &output::new(10, x"0014841b80d2cc75f5345c482af96294d04fdd66b2b7");
+    assert_eq!(output.is_P2WPHK(), true);
+    assert_eq!(output.extract_public_key_hash(), x"841b80d2cc75f5345c482af96294d04fdd66b2b7");
+    let output = &output::new(10, x"0101"); // arbitrary script
+    assert_eq!(output.is_P2PHK(), false);
+    assert_eq!(output.is_P2WPHK(), false);
+    assert_eq!(output.extract_public_key_hash(), vector[]);
+}
+
+#[test]
+fun op_return_script_happy_cases() {
+    let data = vector[
+        x"6a0b68656c6c6f20776f726c64",
+        x"6a",
+        x"6a4c0401020304",
+        x"6a4d0300010203",
+        x"6a4e03000000010203",
+    ];
+    let expected_result = vector[x"68656c6c6f20776f726c64", x"", x"01020304", x"010203", x"010203"];
+
+    data.length().do!(|i| {
+        let o = &output::new(0, data[i]);
+        // this return error code at test index fails
+        assert_eq!(o.is_op_return(), true);
+        assert_eq!(o.op_return(), expected_result[i]);
+    });
+
+    let output = &output::new(100, x"76a91455ae51684c43435da751ac8d2173b2652eb6410588ac");
+    assert_eq!(output.is_op_return(), false);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
<!-- markdownlint-disable MD012 -->

## Description

Move Output APIS from sui-bitcoin-spv to btc parser

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Add script parsing utilities to the BTC parser by moving output APIs into the module, defining script opcode constants, and providing functions to identify P2PKH, P2WPKH, and OP_RETURN outputs as well as extract their payloads.

New Features:
- Detect P2PKH, P2WPKH, and OP_RETURN output scripts.
- Extract public key hash and OP_RETURN data from transaction outputs.

Enhancements:
- Move output-related APIs from sui-bitcoin-spv into the btc_parser module.
- Introduce Bitcoin script opcode constants in the output module.

Tests:
- Add unit tests for script type detection and data extraction across various output scenarios.