### PR TITLE
chore(nBTC):move verify payment to nbtc

### DIFF
--- a/nBTC/Move.lock
+++ b/nBTC/Move.lock
@@ -68,6 +68,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.51.1"
+compiler-version = "1.53.2"
 edition = "2024.beta"
 flavor = "sui"

--- a/nBTC/Move.lock
+++ b/nBTC/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "034FF67E55F098C92B2116A70AA5EEB22D769D2AFE0C424624EF54D4E594CD14"
+manifest_digest = "A463F2786B6F012F6659B9F9EAAF173DDCBCCBC128AE568105270F4C0F23E3AC"
 deps_digest = "52B406A7A21811BEF51751CF88DA0E76DAEFFEAC888D4F4060B1A72BBE7D8D35"
 dependencies = [
   { id = "BitcoinSPV", name = "BitcoinSPV" },
@@ -15,7 +15,7 @@ dependencies = [
 
 [[move.package]]
 id = "BitcoinSPV"
-source = { git = "https://github.com/gonative-cc/move-bitcoin-spv.git", rev = "master", subdir = "./" }
+source = { git = "https://github.com/gonative-cc/sui-bitcoin-spv.git", rev = "dev", subdir = "./" }
 
 dependencies = [
   { id = "Bridge", name = "Bridge" },
@@ -27,7 +27,7 @@ dependencies = [
 
 [[move.package]]
 id = "Bridge"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "6a2fc3c8f555", subdir = "crates/sui-framework/packages/bridge" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/bridge" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -37,11 +37,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "6a2fc3c8f555", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "6a2fc3c8f555", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -49,7 +49,7 @@ dependencies = [
 
 [[move.package]]
 id = "SuiSystem"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "6a2fc3c8f555", subdir = "crates/sui-framework/packages/sui-system" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/sui-system" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -68,6 +68,6 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.52.2"
+compiler-version = "1.51.1"
 edition = "2024.beta"
 flavor = "sui"

--- a/nBTC/Move.toml
+++ b/nBTC/Move.toml
@@ -5,7 +5,7 @@ license = "MPL-2.0"
 authors = ["Native"]
 
 [dependencies]
-BitcoinSPV = { git = "https://github.com/gonative-cc/move-bitcoin-spv.git", subdir = "./", rev = "dev" }
+BitcoinSPV = { git = "https://github.com/gonative-cc/sui-bitcoin-spv.git", subdir = "./", rev = "dev" }
 btc_parser = { git = "https://github.com/gonative-cc/sui-native", subdir = "./btc_parser", rev = "master" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.

--- a/nBTC/Move.toml
+++ b/nBTC/Move.toml
@@ -5,7 +5,7 @@ license = "MPL-2.0"
 authors = ["Native"]
 
 [dependencies]
-BitcoinSPV = { git = "https://github.com/gonative-cc/move-bitcoin-spv.git", subdir = "./", rev = "master" }
+BitcoinSPV = { git = "https://github.com/gonative-cc/move-bitcoin-spv.git", subdir = "./", rev = "dev" }
 btc_parser = { git = "https://github.com/gonative-cc/sui-native", subdir = "./btc_parser", rev = "master" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.

--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -3,7 +3,7 @@
 /// Module: nbtc
 module nbtc::nbtc;
 
-use bitcoin_spv::light_client::{LightClient, verify_payment};
+use bitcoin_spv::light_client::LightClient;
 use btc_parser::reader;
 use btc_parser::tx;
 use sui::address;

--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -3,6 +3,8 @@
 /// Module: nbtc
 module nbtc::nbtc;
 
+use nbtc::verify_payment::verify_payment;
+
 use bitcoin_spv::light_client::LightClient;
 use btc_parser::reader;
 use btc_parser::tx;
@@ -140,7 +142,8 @@ public fun mint(
     let mut r = reader::new(tx_bytes);
     let tx = tx::deserialize(&mut r);
 
-    let (amount_satoshi, op_return, tx_id) = light_client.verify_payment(
+    let (amount_satoshi, op_return, tx_id) = verify_payment(
+	light_client,
         height,
         proof,
         tx_index,

--- a/nBTC/sources/verify_payment.move
+++ b/nBTC/sources/verify_payment.move
@@ -1,0 +1,49 @@
+module nbtc::verify_payment;
+
+
+use bitcoin_spv::light_client::LightClient;
+use btc_parser::tx::Transaction;
+
+#[error]
+const ETxNotInBlock: vector<u8> =
+    b"The transaction is not included in a finalized block according to the Merkle proof";
+
+/// Verifies the transaction and parses outputs to calculates the payment to the receiver.
+/// To if you only want to verify if the tx is included in the block, you can use
+/// `verify_tx` function.
+/// Returns the the total amount of satoshi send to `receiver_address` from transaction outputs,
+/// the content of the `OP_RETURN` opcode output, and tx_id (hash).
+/// If OP_RETURN is not included in the transaction, return an empty vector.
+/// NOTE: output with OP_RETURN is invalid, and only one such output can be included in a TX.
+/// * `height`: block height the transaction belongs to.
+/// * `proof`: merkle tree proof, this is the vector of 32bytes.
+/// * `tx_index`: index of transaction in block.
+/// * `transaction`: bitcoin transaction. Check transaction.move.
+/// * `receiver_pk_hash`: receiver public key hash in p2pkh or p2wpkh. Must not empty
+public fun verify_payment(
+    lc: &LightClient,
+    height: u64,
+    proof: vector<vector<u8>>,
+    tx_index: u64,
+    transaction: &Transaction,
+    receiver_pk_hash: vector<u8>,
+): (u64, vector<u8>, vector<u8>) {
+
+    let mut amount = 0;
+    let mut op_return_msg = vector[];
+    let tx_id = transaction.tx_id();
+
+    assert!(lc.verify_tx(height, tx_id, proof, tx_index), ETxNotInBlock);
+    let outputs = transaction.outputs();
+    outputs.do!(|o| {
+        if (o.extract_public_key_hash() == receiver_pk_hash) {
+            amount = amount + o.amount();
+        };
+
+        if (o.is_op_return()) {
+            op_return_msg = o.op_return();
+        };
+    });
+
+    (amount, op_return_msg, tx_id)
+}

--- a/nBTC/tests/nbtc_tests.move
+++ b/nBTC/tests/nbtc_tests.move
@@ -3,7 +3,7 @@
 #[test_only]
 module nbtc::nbtc_tests;
 
-use bitcoin_spv::light_client::{initialize_light_client, LightClient};
+use bitcoin_spv::light_client::{new_light_client, LightClient};
 use bitcoin_spv::block_header::new_block_header;
 
 use nbtc::nbtc::{
@@ -94,10 +94,7 @@ fun setup(btc_treasury: vector<u8>, sender: address): (LightClient, WrappedTreas
         new_block_header(x"00000020a97594d6b5b9369535da225d464bde7e0ae3794e9b270a010000000000000000234edbf5d62a2790addd8d3fc85727c58c301ddbdebd2738c8f72fb6427ce722bb27e8585a330218b119eaee"),
     ];
 
-    initialize_light_client(0, 0, headers, 0, 0, scenario.ctx());
-
-    scenario.next_tx(sender);
-    let lc: LightClient = scenario.take_shared();
+    let lc = new_light_client(bitcoin_spv::params::regtest(), 0, headers, 0, 0, scenario.ctx());
 
     let mut cap = nbtc::init_for_testing(scenario.ctx());
     cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);

--- a/nBTC/tests/nbtc_tests.move
+++ b/nBTC/tests/nbtc_tests.move
@@ -3,8 +3,9 @@
 #[test_only]
 module nbtc::nbtc_tests;
 
-use bitcoin_spv::light_client::{new_light_client, LightClient};
-use bitcoin_spv::params;
+use bitcoin_spv::light_client::{initialize_light_client, LightClient};
+use bitcoin_spv::block_header::new_block_header;
+
 use nbtc::nbtc::{
     Self,
     WrappedTreasuryCap,
@@ -86,21 +87,27 @@ fun get_fallback_mint_data(): TestData {
 }
 
 #[test_only]
-fun setup(btc_treasury: vector<u8>, ctx: &mut TxContext): (LightClient, WrappedTreasuryCap) {
+fun setup(btc_treasury: vector<u8>, sender: address): (LightClient, WrappedTreasuryCap, Scenario) {
+    let mut scenario = test_scenario::begin(sender);
+
     let headers = vector[
-        x"00000020a97594d6b5b9369535da225d464bde7e0ae3794e9b270a010000000000000000234edbf5d62a2790addd8d3fc85727c58c301ddbdebd2738c8f72fb6427ce722bb27e8585a330218b119eaee",
+        new_block_header(x"00000020a97594d6b5b9369535da225d464bde7e0ae3794e9b270a010000000000000000234edbf5d62a2790addd8d3fc85727c58c301ddbdebd2738c8f72fb6427ce722bb27e8585a330218b119eaee"),
     ];
-    let lc = new_light_client(params::mainnet(), 0, headers, 0, 0, ctx);
-    let mut cap = nbtc::init_for_testing(ctx);
+
+    initialize_light_client(0, 0, headers, 0, 0, scenario.ctx());
+
+    scenario.next_tx(sender);
+    let lc: LightClient = scenario.take_shared();
+
+    let mut cap = nbtc::init_for_testing(scenario.ctx());
     cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, btc_treasury);
-    (lc, cap)
+    (lc, cap, scenario)
 }
 
 #[test]
 fun test_nbtc_mint() {
     let sender = @0x1;
-    let mut scenario = test_scenario::begin(sender);
-    let (lc, mut cap) = setup(BTC_TREASURY, scenario.ctx());
+    let (lc, mut cap, mut scenario) = setup(BTC_TREASURY, sender);
 
     mint_and_assert(
         &mut scenario,
@@ -118,8 +125,7 @@ fun test_nbtc_mint() {
 #[test]
 fun test_nbtc_mint_fallback() {
     let sender = @0x1;
-    let mut scenario = test_scenario::begin(sender);
-    let (lc, mut cap) = setup(BTC_TREASURY, scenario.ctx());
+    let (lc, mut cap, mut scenario) = setup(BTC_TREASURY, sender);
 
     mint_and_assert(
         &mut scenario,
@@ -138,9 +144,8 @@ fun test_nbtc_mint_fallback() {
 #[expected_failure(abort_code = EMintAmountIsZero)]
 fun test_nbtc_mint_fail_amount_is_zero() {
     let sender = @0x1;
-    let mut scenario = test_scenario::begin(sender);
     // Use a different treasury address so the payment to our main treasury is not found.
-    let (lc, mut cap) = setup(x"509a651dd392e1bc125323f629b67d65cca3d4ff", scenario.ctx());
+    let (lc, mut cap, mut scenario) = setup(x"509a651dd392e1bc125323f629b67d65cca3d4ff", sender);
     let data = get_valid_mint_data();
 
     nbtc::mint(
@@ -162,8 +167,7 @@ fun test_nbtc_mint_fail_amount_is_zero() {
 #[expected_failure(abort_code = ETxAlreadyUsed)]
 fun test_nbtc_mint_fail_tx_already_used() {
     let sender = @0x1;
-    let mut scenario = test_scenario::begin(sender);
-    let (lc, mut cap) = setup(BTC_TREASURY, scenario.ctx());
+    let (lc, mut cap, mut scenario) = setup(BTC_TREASURY, sender);
     let data = get_valid_mint_data();
 
     // First mint, should succeed
@@ -196,21 +200,15 @@ fun test_nbtc_mint_fail_tx_already_used() {
 #[test, expected_failure(abort_code = EAlreadyUpdated)]
 fun test_update_version_fail() {
     let sender = @0x01;
-    let mut scenario = test_scenario::begin(sender);
-    let ctx = scenario.ctx();
-    let (lc, mut cap) = setup(BTC_TREASURY, ctx);
+    let (_lc, mut cap, _scenario) = setup(BTC_TREASURY, sender);
     nbtc::update_version(&mut cap);
-    destroy(lc);
-    destroy(cap);
-    scenario.end();
+    abort
 }
 
 #[test, expected_failure(abort_code = nbtc::EReSetupTreasuryNotAllow)]
 fun test_re_setup_treasury_should_fail() {
     let sender = @0x01;
-    let mut scenario = test_scenario::begin(sender);
-    let ctx = scenario.ctx();
-    let (lc, mut cap) = setup(BTC_TREASURY, ctx);
+    let (lc, mut cap, _scenario) = setup(BTC_TREASURY, sender);
     // resetup, should fail
     cap.setup(lc.client_id().to_address(), FALLBACK_ADDR, BTC_TREASURY);
 

--- a/nBTC/tests/prove_payment_tests.move
+++ b/nBTC/tests/prove_payment_tests.move
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#[test_only]
+module nbtc::verify_payment_tests_;
+
+use bitcoin_spv::block_header::new_block_header;
+use bitcoin_spv::light_client::{new_light_client, ETxNotInBlock};
+use bitcoin_spv::params;
+use btc_parser::reader;
+use btc_parser::tx;
+use std::unit_test::assert_eq;
+use sui::test_scenario;
+
+#[test]
+fun verify_payment_happy_cases() {
+    let sender = @0x01;
+    let mut scenario = test_scenario::begin(sender);
+    let start_block_height = 325001;
+    let headers = vector[
+        x"020000005d42717a33dd7046b6ca5fa33f14a7318b8221ce5b6909040000000000000000d7ee3bfa38399e87f302a41b388f33df29bf3ecb3552ed208a4869e17870a74d5c843a5473691f184c13685d",
+        x"02000000467aa6383f1aad95ed5c4eee2dc10a97ebb1f79760446a0000000000000000004586bab85aa954c20675b8603c2bc68b53a3da5b0d25a8a03dc3a274ab8c981409863a5473691f186b9c6345",
+        x"020000002e4fd5261bc0c9e663d32f4bbbb3253e3a8f8e5759f7ae070000000000000000046c024dcdabcc5f3071d8f44e030dba6b9ae7e30336523be2a767c68b0e3ba684863a5473691f180220726b",
+        x"02000000ae4bcf449c0e9ea803a663bb09c45f221b62b206353e1e0f000000000000000010638f6182860aa213236fbce7bafc9b68a6f8826d3f05482c4e8cd7465ec9824c8c3a5473691f185c90957a",
+        x"02000000c331af5f49fd96014b398d9541b4d252a8a4235c2797d90b00000000000000003ac10882c715806ec7b557b9de9fd786c0380718335e2ae2c1fbee9fb1465aa03b8c3a5473691f187cd8568e",
+    ].map!(|h| new_block_header(h));
+
+    let ctx = scenario.ctx();
+    let finality = 4; // => the block 325001 is finally in this case
+    let lc = new_light_client(
+        params::mainnet(),
+        start_block_height,
+        headers,
+        0,
+        finality,
+        ctx,
+    );
+
+    // merkle proof of transaction id gen by proof.py in scripts folder.
+
+    let proof = vector[
+        x"38636d3258913a5c593a17323ddb0f34e1596b77c2860d67296f124f97df8376",
+        x"fd6fd6c1d48b37c044911cda5795854e5efdfdb947d7eb806ad8ace6c946683a",
+        x"a17bd716526b15b4605a0775c5d3944fa65870f375db94cd76db1d824e78efe6",
+        x"75d8e49d7be1d7a8bf971256cc8af5d208e3da0412f756af66141a6ba9ed74a5",
+        x"9d69430ab8f262ede0e5b25652e361937a4f96c4400b764ff8d81abeef620852",
+        x"f32111d27d0765ef0cbf7093a8e16e3c2c69bb1bc11d05af7e28b82361402244",
+        x"2f894c0db71838edd489501fff01befe343d013ee3a75e83ec35d561d9abad19",
+        x"e6a7942ff80cdaef030d915a5300d19700bf37e8c10fab7959e47178e0b74f69",
+        x"888039325588c2afd748854fd66c565d1e25d0b18d9f00fe9c881a6830cf3614",
+        x"90aa501ce00f5bc4b756feba07161ff89db6b9c3cf0d632e3c93d08b5bfac2c4",
+        x"e99c4dfa417d61179440f88baf7e9fb798c744eb1139dbd15ea90d6ab3ccb8aa",
+    ];
+
+    let tx_index = 604;
+    let mut r = reader::new(
+        x"01000000018c0bfefccb5755874ea0872a17b0d682c84981eed93fccd3ef86556f51f21522010000006a47304402204bbbefdc49e7289b0f36fe8c7623e93ff7ff751664d63caf49c1d9d8a4cbefd402200582f12a9490bdf8e6980025c08f83c43c50bc472706e3a38e7f1a972404bc4d0121035533036f3a7e9dc4c76e9d3697eb9d573aa76844baaadda347893a793797b639ffffffff0410270000000000001976a914303962c3ad29f08d13d98218ceeb7057e9bc184888ac10270000000000001976a914c6a3b95415d3fe9a9161c4b5100c1b6f2ad1e90c88ac00000000000000000d6a0b68656c6c6f20776f726c64e5490600000000001976a914e6228f7a5ee6b15c7cccfd9f9cb7e8699261084588ac00000000",
+    );
+    let transaction = tx::deserialize(&mut r);
+
+    // Tx: 6dfb16dd580698242bcfd8e433d557ed8c642272a368894de27292a8844a4e75 (Height 303,699)
+    // from mainnet
+    let (amount, message, tx_id) = lc.verify_payment(
+        start_block_height,
+        proof,
+        tx_index,
+        &transaction,
+        x"e6228f7a5ee6b15c7cccfd9f9cb7e86992610845",
+    );
+
+    assert_eq!(tx_id, x"754e4a84a89272e24d8968a37222648ced57d533e4d8cf2b24980658dd16fb6d");
+    assert_eq!(amount, 412133);
+    assert_eq!(message, x"68656c6c6f20776f726c64");
+    sui::test_utils::destroy(lc);
+    scenario.end();
+}
+
+#[test]
+fun verify_payment_with_P2WPHK_output_happy_cases() {
+    let sender = @0x01;
+    let mut scenario = test_scenario::begin(sender);
+    let start_block_height = 0;
+    let headers = vector[
+        // only one transaction
+        new_block_header(
+            x"020000005d42717a33dd7046b6ca5fa33f14a7318b8221ce5b6909040000000000000000df88e4ad22477438db0a80979cf3dea033aa968c97fe06270f8864941a30649b5c843a5473691f184c13685d",
+        ),
+    ];
+
+    let ctx = scenario.ctx();
+    let finality = 0;
+    let lc = new_light_client(
+        params::regtest(),
+        start_block_height,
+        headers,
+        0,
+        finality,
+        ctx,
+    );
+
+    // empty because only one transaction
+    let proof = vector[];
+
+    let tx_index = 604;
+
+    let mut r = reader::new(
+        x"01000000018c0bfefccb5755874ea0872a17b0d682c84981eed93fccd3ef86556f51f21522010000006a47304402204bbbefdc49e7289b0f36fe8c7623e93ff7ff751664d63caf49c1d9d8a4cbefd402200582f12a9490bdf8e6980025c08f83c43c50bc472706e3a38e7f1a972404bc4d0121035533036f3a7e9dc4c76e9d3697eb9d573aa76844baaadda347893a793797b639ffffffff0410270000000000001976a914303962c3ad29f08d13d98218ceeb7057e9bc184888ac10270000000000001976a914c6a3b95415d3fe9a9161c4b5100c1b6f2ad1e90c88ac00000000000000000d6a0b68656c6c6f20776f726c64e549060000000000160014e6228f7a5ee6b15c7cccfd9f9cb7e8699261084500000000",
+    );
+    let transaction = tx::deserialize(&mut r);
+
+    let (amount, message, tx_id) = lc.verify_payment(
+        start_block_height,
+        proof,
+        tx_index,
+        &transaction,
+        x"e6228f7a5ee6b15c7cccfd9f9cb7e86992610845",
+    );
+
+    assert_eq!(tx_id, x"df88e4ad22477438db0a80979cf3dea033aa968c97fe06270f8864941a30649b");
+    assert_eq!(amount, 412133);
+    assert_eq!(message, x"68656c6c6f20776f726c64");
+    sui::test_utils::destroy(lc);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = ETxNotInBlock)]
+fun verify_payment_for_tx_not_in_block_shoul_fail() {
+    let sender = @0x01;
+    let mut scenario = test_scenario::begin(sender);
+    let start_block_height = 325001;
+    let headers = vector[
+        new_block_header(
+            x"020000005d42717a33dd7046b6ca5fa33f14a7318b8221ce5b6909040000000000000000d7ee3bfa38399e87f302a41b388f33df29bf3ecb3552ed208a4869e17870a74d5c843a5473691f184c13685d",
+        ),
+    ];
+    let ctx = scenario.ctx();
+    let lc = new_light_client(params::mainnet(), start_block_height, headers, 0, 8, ctx);
+
+    // merkle proof of transaction id gen by proof.py in scripts folder.
+    // we modify proof to make this invalid.
+    let proof = vector[
+        x"54b37ab185afd67209bd0788a11a82dfb161ecd76f366e5fa8130ab74e11a5a7",
+        x"3e19ed90a5d77f57b8237905c32a0629c558ae371a7c05afc47955589226b478",
+        x"8d05f8415375a5069054cc39912759a3d5059300cd98354f82f958f086e057aa",
+        x"dbde00ca9c3695c40bf6d7f4abd929cf8f385422d8a6e92c046f04e16fdafef1",
+        x"0872911bd9c77c528f448ab4b3dcf794ceaf925384c5b1b78ba48c035a10e3eb",
+        x"3f335c1ed5bfee45640f9c32611fffe9070974419e0ed0c850533be9c30dc82b",
+        x"4f8c12cf241447aeaabe794dee1dd9e7caee23a93ff33c33aa0c81fe2fc3b0b1",
+        x"b95b666c9b6ae55cede0667f6de31430997eacdc264e9e50a0f93aef35d83104",
+        x"6efa6c0e97e8d9cf95577e088f5bf27d0c5e08523944b15694b1e6681a323553",
+        x"b88d2e3a29eb772ae27aec10f33e594c0a108db5d4cbb8ea6a383371cd2e346a",
+        x"2e7ed7831d341177f75647c7ce999efede045099c396c18be790b0d1a5aeffff", // <-- modified here, 83cb => ffff
+    ];
+
+    let tx_index = 604;
+
+    let mut r = reader::new(
+        x"0100000001c08ce0edcedc47becf03f923479bec4c184cda060452959f59d47ae8923da032010000006b483045022100cfdcc3fc354c8d2bbf22d708723e1c3836629c0ed6ef9485004d674ca06e0c6102204dee8d1180a309d22aa66e83554d992b751298208bc1b1e0d60f74fe834634330121036b4468fc9f4dc283365c70f7989b944586a260fca5358a91dfc50bf13c071b1effffffff0220a10700000000001976a9140fef69f3ac0d9d0473a318ae508875ad0eae3dcc88acc8ec7100000000001976a91451e6b602f387b4c5bb8a4d8cdf1b059c826374e388ac00000000",
+    );
+    let transaction = tx::deserialize(&mut r);
+    // Tx: dc7ed74b93823c33544436cda1ea66761d708aafe08b80cd69c4f42d049a703c (Height 303,699)
+    // from mainnet
+    // should return error
+    lc.verify_payment(
+        start_block_height,
+        proof,
+        tx_index,
+        &transaction,
+        x"e6228f7a5ee6b15c7cccfd9f9cb7e86992610845",
+    );
+
+    sui::test_utils::destroy(lc);
+    scenario.end();
+}
+
+#[test, expected_failure(abort_code = ETxNotInBlock)]
+fun verify_payment_on_block_not_finalize_should_fail() {
+    let sender = @0x01;
+    let mut scenario = test_scenario::begin(sender);
+    let start_block_height = 325001;
+    let headers = vector[
+        new_block_header(
+            x"020000005d42717a33dd7046b6ca5fa33f14a7318b8221ce5b6909040000000000000000d7ee3bfa38399e87f302a41b388f33df29bf3ecb3552ed208a4869e17870a74d5c843a5473691f184c13685d",
+        ),
+    ];
+    let ctx = scenario.ctx();
+    let lc = new_light_client(params::mainnet(), start_block_height, headers, 0, 8, ctx);
+
+    // merkle proof of transaction id gen by proof.py in scripts folder.
+    // we modify proof to make this invalid.
+    let proof = vector[
+        x"54b37ab185afd67209bd0788a11a82dfb161ecd76f366e5fa8130ab74e11a5a7",
+        x"3e19ed90a5d77f57b8237905c32a0629c558ae371a7c05afc47955589226b478",
+        x"8d05f8415375a5069054cc39912759a3d5059300cd98354f82f958f086e057aa",
+        x"dbde00ca9c3695c40bf6d7f4abd929cf8f385422d8a6e92c046f04e16fdafef1",
+        x"0872911bd9c77c528f448ab4b3dcf794ceaf925384c5b1b78ba48c035a10e3eb",
+        x"3f335c1ed5bfee45640f9c32611fffe9070974419e0ed0c850533be9c30dc82b",
+        x"4f8c12cf241447aeaabe794dee1dd9e7caee23a93ff33c33aa0c81fe2fc3b0b1",
+        x"b95b666c9b6ae55cede0667f6de31430997eacdc264e9e50a0f93aef35d83104",
+        x"6efa6c0e97e8d9cf95577e088f5bf27d0c5e08523944b15694b1e6681a323553",
+        x"b88d2e3a29eb772ae27aec10f33e594c0a108db5d4cbb8ea6a383371cd2e346a",
+        x"2e7ed7831d341177f75647c7ce999efede045099c396c18be790b0d1a5ae83cb", // <-- modified here, 83cb => ffff
+    ];
+
+    let tx_index = 604;
+    let mut r = reader::new(
+        x"0100000001c08ce0edcedc47becf03f923479bec4c184cda060452959f59d47ae8923da032010000006b483045022100cfdcc3fc354c8d2bbf22d708723e1c3836629c0ed6ef9485004d674ca06e0c6102204dee8d1180a309d22aa66e83554d992b751298208bc1b1e0d60f74fe834634330121036b4468fc9f4dc283365c70f7989b944586a260fca5358a91dfc50bf13c071b1effffffff0220a10700000000001976a9140fef69f3ac0d9d0473a318ae508875ad0eae3dcc88acc8ec7100000000001976a91451e6b602f387b4c5bb8a4d8cdf1b059c826374e388ac00000000",
+    );
+    let transaction = tx::deserialize(&mut r);
+
+    // Tx: dc7ed74b93823c33544436cda1ea66761d708aafe08b80cd69c4f42d049a703c (Height 303,699)
+    // from mainnet
+    // should return error
+    lc.verify_payment(
+        start_block_height,
+        proof,
+        tx_index,
+        &transaction,
+        x"e6228f7a5ee6b15c7cccfd9f9cb7e86992610845",
+    );
+
+    sui::test_utils::destroy(lc);
+    scenario.end();
+}

--- a/nBTC/tests/verify_payment_tests.move
+++ b/nBTC/tests/verify_payment_tests.move
@@ -6,7 +6,7 @@ module nbtc::verify_payment_tests;
 use nbtc::verify_payment::{verify_payment, ETxNotInBlock};
 
 use bitcoin_spv::block_header::new_block_header;
-use bitcoin_spv::light_client::{initialize_light_client, LightClient};
+use bitcoin_spv::light_client::new_light_client;
 use btc_parser::reader;
 use btc_parser::tx;
 use std::unit_test::assert_eq;
@@ -27,18 +27,14 @@ fun verify_payment_happy_cases() {
 
     let ctx = scenario.ctx();
     let finality = 4; // => the block 325001 is finally in this case
-    initialize_light_client(
-        0, // mainnet
+    let lc = new_light_client(
+        bitcoin_spv::params::mainnet(),
         start_block_height,
         headers,
         0,
         finality,
         ctx,
     );
-
-    scenario.next_tx(sender);
-
-    let lc: LightClient = test_scenario::take_shared(&scenario);
     // merkle proof of transaction id gen by proof.py in scripts folder.
 
     let proof = vector[
@@ -94,16 +90,14 @@ fun verify_payment_with_P2WPHK_output_happy_cases() {
     let ctx = scenario.ctx();
     let finality = 0;
 
-    initialize_light_client(
-        0,
+    let lc = new_light_client(
+        bitcoin_spv::params::mainnet(),
         start_block_height,
         headers,
         0,
         finality,
         ctx,
     );
-
-    let lc: LightClient = test_scenario::take_shared(&scenario);
 
     // empty because only one transaction
     let proof = vector[];
@@ -142,10 +136,7 @@ fun verify_payment_for_tx_not_in_block_shoul_fail() {
         ),
     ];
     let ctx = scenario.ctx();
-    // 0 = mainnet
-    initialize_light_client(0, start_block_height, headers, 0, 8, ctx);
-
-    let lc: LightClient = test_scenario::take_shared(&scenario);
+    let lc = new_light_client(bitcoin_spv::params::mainnet(), start_block_height, headers, 0, 8, ctx);
 
     // merkle proof of transaction id gen by proof.py in scripts folder.
     // we modify proof to make this invalid.
@@ -196,8 +187,7 @@ fun verify_payment_on_block_not_finalize_should_fail() {
         ),
     ];
     let ctx = scenario.ctx();
-    initialize_light_client(0, start_block_height, headers, 0, 8, ctx);
-    let lc: LightClient = test_scenario::take_shared(&scenario);
+    let lc = new_light_client(bitcoin_spv::params::mainnet(), start_block_height, headers, 0, 8, ctx);
 
     // merkle proof of transaction id gen by proof.py in scripts folder.
     // we modify proof to make this invalid.


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Extract verify_payment logic into its own module, integrate it into the mint flow, refactor tests to use test_scenario and new_block_header, and update the BitcoinSPV dependency.

New Features:
- Extract payment verification into a standalone nbtc::verify_payment module
- Add comprehensive unit tests for verify_payment covering happy paths and failure cases

Enhancements:
- Refactor nbtc mint logic to call the new verify_payment function instead of light_client.verify_payment
- Update nbtc test setup to return a Scenario, use test_scenario for context, and wrap raw headers with new_block_header

Build:
- Bump BitcoinSPV dependency to the ‘sui-bitcoin-spv’ dev branch

Tests:
- Migrate existing nbtc tests to use the updated setup signature and new_block_header utility
- Add verify_payment_tests.move with end-to-end tests for OP_RETURN and P2WPKH outputs and error scenarios