### PR TITLE
refactor: Rename `block_header` module to `header`

### DIFF
--- a/btc_parser/sources/block.move
+++ b/btc_parser/sources/block.move
@@ -2,7 +2,7 @@
 
 module btc_parser::block;
 
-use btc_parser::block_header::{Self, BlockHeader};
+use btc_parser::header::{Self, BlockHeader};
 use btc_parser::reader;
 use btc_parser::tx::{Self, Transaction};
 
@@ -17,7 +17,7 @@ public struct Block has copy, drop {
 
 public fun new(raw_block: vector<u8>): Block {
     let mut r = reader::new(raw_block);
-    let block_header = block_header::new(r.read(80));
+    let block_header = header::new(r.read(80));
     let number_tx = r.read_compact_size();
     let mut transactions = vector[];
     number_tx.do!(|_| {

--- a/btc_parser/sources/block_header.move
+++ b/btc_parser/sources/block_header.move
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-module btc_parser::block_header;
+module btc_parser::header;
 
 use btc_parser::crypto::hash256;
 use btc_parser::reader;


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Rename the block_header module to header to resolve naming conflict and update related imports and references in block parsing code.

Chores:
- Rename module btc_parser::block_header to btc_parser::header
- Update imports and calls in block.move to reference the renamed header module