### PR TITLE
fix(nBTC): update types return in verify_payment

### DIFF
--- a/nBTC/Move.lock
+++ b/nBTC/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 3
-manifest_digest = "A463F2786B6F012F6659B9F9EAAF173DDCBCCBC128AE568105270F4C0F23E3AC"
+manifest_digest = "3B6CE811E0C118BB52C5C2F4B02E1B2FE399B6AC92FEF030C60959472D0DE8C2"
 deps_digest = "52B406A7A21811BEF51751CF88DA0E76DAEFFEAC888D4F4060B1A72BBE7D8D35"
 dependencies = [
   { id = "BitcoinSPV", name = "BitcoinSPV" },
@@ -15,7 +15,7 @@ dependencies = [
 
 [[move.package]]
 id = "BitcoinSPV"
-source = { git = "https://github.com/gonative-cc/sui-bitcoin-spv.git", rev = "dev", subdir = "./" }
+source = { git = "https://github.com/gonative-cc/sui-bitcoin-spv.git", rev = "master", subdir = "./" }
 
 dependencies = [
   { id = "Bridge", name = "Bridge" },
@@ -27,7 +27,7 @@ dependencies = [
 
 [[move.package]]
 id = "Bridge"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/bridge" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "b448b1d971bd6c1aac8ef4eee4305943806d5d5b", subdir = "crates/sui-framework/packages/bridge" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -37,11 +37,11 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "b448b1d971bd6c1aac8ef4eee4305943806d5d5b", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "b448b1d971bd6c1aac8ef4eee4305943806d5d5b", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -49,7 +49,7 @@ dependencies = [
 
 [[move.package]]
 id = "SuiSystem"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "2c930c25f8d3", subdir = "crates/sui-framework/packages/sui-system" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "b448b1d971bd6c1aac8ef4eee4305943806d5d5b", subdir = "crates/sui-framework/packages/sui-system" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },

--- a/nBTC/tests/verify_payment_tests.move
+++ b/nBTC/tests/verify_payment_tests.move
@@ -57,9 +57,10 @@ fun verify_payment_happy_cases() {
     );
     let transaction = tx::deserialize(&mut r);
 
+    let tx_id = transaction.tx_id();
     // Tx: 6dfb16dd580698242bcfd8e433d557ed8c642272a368894de27292a8844a4e75 (Height 303,699)
     // from mainnet
-    let (amount, message, tx_id) = verify_payment(
+    let (amount,mut message) = verify_payment(
 	&lc,
         start_block_height,
         proof,
@@ -70,7 +71,7 @@ fun verify_payment_happy_cases() {
 
     assert_eq!(tx_id, x"754e4a84a89272e24d8968a37222648ced57d533e4d8cf2b24980658dd16fb6d");
     assert_eq!(amount, 412133);
-    assert_eq!(message, x"68656c6c6f20776f726c64");
+    assert_eq!(message.extract(), x"68656c6c6f20776f726c64");
     sui::test_utils::destroy(lc);
     scenario.end();
 }
@@ -108,8 +109,8 @@ fun verify_payment_with_P2WPHK_output_happy_cases() {
         x"01000000018c0bfefccb5755874ea0872a17b0d682c84981eed93fccd3ef86556f51f21522010000006a47304402204bbbefdc49e7289b0f36fe8c7623e93ff7ff751664d63caf49c1d9d8a4cbefd402200582f12a9490bdf8e6980025c08f83c43c50bc472706e3a38e7f1a972404bc4d0121035533036f3a7e9dc4c76e9d3697eb9d573aa76844baaadda347893a793797b639ffffffff0410270000000000001976a914303962c3ad29f08d13d98218ceeb7057e9bc184888ac10270000000000001976a914c6a3b95415d3fe9a9161c4b5100c1b6f2ad1e90c88ac00000000000000000d6a0b68656c6c6f20776f726c64e549060000000000160014e6228f7a5ee6b15c7cccfd9f9cb7e8699261084500000000",
     );
     let transaction = tx::deserialize(&mut r);
-
-    let (amount, message, tx_id) = verify_payment(
+    let tx_id = transaction.tx_id();
+    let (amount, mut message) = verify_payment(
 	&lc,
         start_block_height,
         proof,
@@ -120,7 +121,7 @@ fun verify_payment_with_P2WPHK_output_happy_cases() {
 
     assert_eq!(tx_id, x"df88e4ad22477438db0a80979cf3dea033aa968c97fe06270f8864941a30649b");
     assert_eq!(amount, 412133);
-    assert_eq!(message, x"68656c6c6f20776f726c64");
+    assert_eq!(message.extract(), x"68656c6c6f20776f726c64");
     sui::test_utils::destroy(lc);
     scenario.end();
 }


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Simplify payment verification by returning only the transferred amount and an optional OP_RETURN payload, and adapt minting logic and tests to the new signature

Enhancements:
- Change verify_payment to return (amount, Option<op_return>) instead of including tx_id
- Update mint function to use a fallback address and override it when OP_RETURN contains a 32-byte address
- Adjust tests to call the updated verify_payment signature and extract bytes from the Option type