### PR TITLE
ci: fix js setup

### DIFF
--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -21,30 +21,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      ### version with cache
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "pnpm"
-      - name: Install dependencies
-        run: pnpm install
-      ###
+      # @v2
+      - uses: oven-sh/setup-bun@22457c87c1b161cf7dde222c3e82b2b5f8d2bed2
+      - run: bun ci
 
-      - name: eslint
-        run: "pnpm run lint"
+      - name: lint
+        run: "bun run lint"
 
       - name: typecheck
-        run: "pnpm run typecheck"
-
-      - name: build
-        run: "pnpm run build"
+        run: "bun run typecheck"
 
       - name: test
-        run: "pnpm run test"
+        run: "bun run test"

--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -20,11 +20,12 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
+      # @v2
+      - uses: oven-sh/setup-bun@22457c87c1b161cf7dde222c3e82b2b5f8d2bed2
+      - run: bun install prettier
+
       - name: Prettify code
-        uses: creyD/prettier_action@v4.6
-        with:
-          prettier_options: --no-config -c .
-          only_changed: true
+        run: bun prettier -c .
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -25,7 +25,18 @@ jobs:
       - run: bun install prettier
 
       - name: Prettify code
-        run: bun prettier -c .
+        run: |
+          # Identify the target branch to diff against.
+          TARGET_BRANCH="origin/${{ github.base_ref }}"
+
+          echo "Identifying changed files against branch $TARGET_BRANCH..."
+
+          # Get a list of changed files, separated by NUL characters to handle spaces.
+          # - xargs -0 reads NUL-separated input.
+          # - xargs -r ensures Prettier doesn't run if there are no changed files.
+          # - prettier --check checks formatting without writing changes.
+          git diff --name-only -z --diff-filter=ACMRT $TARGET_BRANCH...HEAD | \
+            xargs -0 -r bun prettier --ignore-unknown --check
 
   test:
     runs-on: ubuntu-latest

--- a/contrib/bitcoin-key-inspect.js
+++ b/contrib/bitcoin-key-inspect.js
@@ -3,6 +3,8 @@ import { BIP32Factory } from "bip32";
 import bitcoin from "bitcoinjs-lib";
 import * as ecc from "tiny-secp256k1";
 
+import { getProperty } from "./objutil.js";
+
 // We must wrap a tiny-secp256k1 compatible implementation
 const bip32 = BIP32Factory(ecc);
 
@@ -21,12 +23,6 @@ const mainnetBIP32 = {
 // 	p2tr: "m/86'/1'/0'/0/0", // taproot
 // 	legacy_p2pkh: "m/44'/1'/0'/0/0", // deprecated
 // };
-
-function getProperty(key, obj, msg) {
-	if (!(key in obj))
-		throw new Error("Wrong" + msg + ": " + key + ", must be in: " + Object.keys(obj));
-	return obj[key];
-}
 
 /**
  * @param {Uint8Array} - bytes.

--- a/contrib/bitcoin-key-inspect.js
+++ b/contrib/bitcoin-key-inspect.js
@@ -8,11 +8,12 @@ const bip32 = BIP32Factory(ecc);
 
 // derivation paths using BIP 44 (derives from BIP 32)
 const mainnetBIP32 = {
-  p2wpkh: "m/84'/0'/0'/0/0", // segwit
-  p2sh: "m/49'/0'/0'/0/0", // nested segwit = p2sh__p2wpkh
-  p2tr: "m/86'/0'/0'/0/0", // taproot
-  legacy_p2pkh: "m/44'/0'/0'/0/0", // deprecated
+	p2wpkh: "m/84'/0'/0'/0/0", // segwit
+	p2sh: "m/49'/0'/0'/0/0", // nested segwit = p2sh__p2wpkh
+	p2tr: "m/86'/0'/0'/0/0", // taproot
+	legacy_p2pkh: "m/44'/0'/0'/0/0", // deprecated
 };
+
 // NOTE: apparently this is not used - the mainnet is also used in testnet!
 // const testnetBIP32 = {
 // 	p2wpkh: "m/84'/1'/0'/0/0", // segwit
@@ -22,11 +23,9 @@ const mainnetBIP32 = {
 // };
 
 function getProperty(key, obj, msg) {
-  if (!(key in obj))
-    throw new Error(
-      "Wrong" + msg + ": " + key + ", must be in: " + Object.keys(obj),
-    );
-  return obj[key];
+	if (!(key in obj))
+		throw new Error("Wrong" + msg + ": " + key + ", must be in: " + Object.keys(obj));
+	return obj[key];
 }
 
 /**
@@ -34,9 +33,9 @@ function getProperty(key, obj, msg) {
  * @returns {string} - hex string of a hash160 (sha256 + ripmed160).
  */
 function hash160Hex(input) {
-  let x = bitcoin.crypto.sha256(input);
-  x = bitcoin.crypto.ripemd160(x);
-  return Buffer.from(x).toString("hex");
+	let x = bitcoin.crypto.sha256(input);
+	x = bitcoin.crypto.ripemd160(x);
+	return Buffer.from(x).toString("hex");
 }
 
 /**
@@ -44,12 +43,12 @@ function hash160Hex(input) {
  * @returns {object} - bitcoinKey.
  */
 function keyFromMnemonic(mnemonic, keyType) {
-  const seed = bip39.mnemonicToSeedSync(mnemonic);
-  const rootKey = bip32.fromSeed(seed);
+	const seed = bip39.mnemonicToSeedSync(mnemonic);
+	const rootKey = bip32.fromSeed(seed);
 
-  const path = getProperty(keyType, mainnetBIP32, "key type");
+	const path = getProperty(keyType, mainnetBIP32, "key type");
 
-  return rootKey.derivePath(path);
+	return rootKey.derivePath(path);
 }
 
 /**
@@ -59,24 +58,20 @@ function keyFromMnemonic(mnemonic, keyType) {
  * @returns {string | null} - The P2WPKH address, or null on error.
  */
 function keyToP2WPKHAddress(bitcoinKey, keyConfig) {
-  const paymentConstructor = getProperty(
-    keyConfig.typ,
-    bitcoin.payments,
-    "key type",
-  );
-  const n = getProperty(keyConfig.network, bitcoin.networks, "key type");
+	const paymentConstructor = getProperty(keyConfig.typ, bitcoin.payments, "key type");
+	const n = getProperty(keyConfig.network, bitcoin.networks, "key type");
 
-  const p = paymentConstructor({
-    pubkey: Buffer.from(bitcoinKey.publicKey),
-    network: n,
-  });
+	const p = paymentConstructor({
+		pubkey: Buffer.from(bitcoinKey.publicKey),
+		network: n,
+	});
 
-  if (!p.address) {
-    console.error("Failed to generate P2WPKH address.");
-    return null;
-  }
+	if (!p.address) {
+		console.error("Failed to generate P2WPKH address.");
+		return null;
+	}
 
-  return p.address;
+	return p.address;
 }
 
 //
@@ -84,26 +79,20 @@ function keyToP2WPKHAddress(bitcoinKey, keyConfig) {
 //
 
 let keyConfig = {
-  network: "testnet", // "bitcoin" | "testnet" | "regtest"
-  typ: "p2wpkh", // "p2wpkh" | "p2sh" | "p2tr" | "legacy_p2pkh"
+	network: "testnet", // "bitcoin" | "testnet" | "regtest"
+	typ: "p2wpkh", // "p2wpkh" | "p2sh" | "p2tr" | "legacy_p2pkh"
 };
 
 let mnemonic =
-  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+	"abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
 let key = keyFromMnemonic(mnemonic, keyConfig.typ);
 
 // Wallet Import Format - a format for private key containing:
 // version, key, compression byte and checksum
 console.log("Bitcoin Private Key (WIF):", key.toWIF());
-console.log(
-  "Bitcoin Private Key (hex):",
-  Buffer.from(key.privateKey).toString("hex"),
-);
-console.log(
-  "Bitcoin Public Key (hex):",
-  Buffer.from(key.publicKey).toString("hex"),
-);
+console.log("Bitcoin Private Key (hex):", Buffer.from(key.privateKey).toString("hex"));
+console.log("Bitcoin Public Key (hex):", Buffer.from(key.publicKey).toString("hex"));
 // this is probably what we need in the move transaction
 console.log("Bitcoin Public Key hash160 (hex):", hash160Hex(key.publicKey));
 

--- a/contrib/objutil.js
+++ b/contrib/objutil.js
@@ -1,0 +1,5 @@
+export function getProperty(key, obj, msg) {
+	if (!(key in obj))
+		throw new Error("Wrong" + msg + ": " + key + ", must be in: " + Object.keys(obj));
+	return obj[key];
+}

--- a/contrib/objutil.test.js
+++ b/contrib/objutil.test.js
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+
+import { getProperty } from "./objutil.js";
+
+test("getProperty", () => {
+	const o1 = { a: 1, b: 10 };
+	const l = [8, 3];
+	expect(getProperty("a", o1)).toBe(1);
+	expect(getProperty("b", o1)).toBe(10);
+	expect(getProperty(0, l)).toBe(8);
+	expect(getProperty(1, l)).toBe(3);
+
+	expect(() => getProperty("other", o1)).toThrowError();
+	expect(() => getProperty(1, o1)).toThrowError();
+	expect(() => getProperty(2, l)).toThrowError();
+});

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "sui-native",
 	"description": "",
-	"version": "0.1.0",
-	"module": "index.ts",
+	"version": "0.0.0",
 	"type": "module",
 	"private": true,
-	"license": "ISC",
+	"license": "MPL-2.0",
+	"packageManager": "bun@1.20.22",
 	"scripts": {
 		"lint": "echo \"Error: no linter specified\"",
 		"typecheck": "tsc --noEmit",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,33 +1,33 @@
 {
-  "compilerOptions": {
-    // Environment setup & latest features
-    "lib": ["ESNext"],
-    "target": "ESNext",
-    "module": "Preserve",
-    "moduleDetection": "force",
-    "allowJs": true,
+	"compilerOptions": {
+		// Environment setup & latest features
+		"lib": ["ESNext"],
+		"target": "ESNext",
+		"module": "Preserve",
+		"moduleDetection": "force",
+		"allowJs": true,
 
-    // Bundler mode
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "noEmit": true,
+		// Bundler mode
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"verbatimModuleSyntax": true,
+		"noEmit": true,
 
-    // Best practices
-    "strict": true,
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "forceConsistentCasingInFileNames": true,
+		// Best practices
+		"strict": true,
+		"skipLibCheck": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitOverride": true,
+		"forceConsistentCasingInFileNames": true,
 
-    // Some stricter flags (disabled by default)
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
+		// Some stricter flags (disabled by default)
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noPropertyAccessFromIndexSignature": false
 
-    // "types": [vitest/globals"],
-  }
-  // with bun we don't need to specify then include
-  // "include": ["scripts/**/*.ts", "scripts/**/*.js", "scripts/vitest.config.ts"]
+		// "types": [vitest/globals"],
+	}
+	// with bun we don't need to specify then include
+	// "include": ["scripts/**/*.ts", "scripts/**/*.js", "scripts/vitest.config.ts"]
 }


### PR DESCRIPTION
## Description

## Summary by Sourcery

Switch JavaScript CI pipeline and project configuration to use Bun instead of pnpm and Node.js

Enhancements:
- Use actions/checkout@v5 in the CI workflow
- Replace pnpm/action-setup and actions/setup-node steps with oven-sh/setup-bun and bun ci
- Run lint, typecheck, and tests with bun run instead of pnpm

Build:
- Add packageManager field for Bun in package.json

Chores:
- Bump project version to 0.0.0
- Change license from ISC to MPL-2.0