### PR TITLE
feat(nbtc): add payload mint arg, to handle op_return payloads. 

### DIFF
--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -145,6 +145,7 @@ fun init(witness: NBTC, ctx: &mut TxContext) {
 /// * `proof`: merkle proof for the tx.
 /// * `height`: block height, where the tx was included.
 /// * `tx_index`: index of the tx within the block.
+/// * `payload`: additional argument that is related to the op_return instruction handling.
 /// * `ops_arg`: operation argument controlling fee application.
 ///   - Pass `1` to apply minting fees.
 ///   - Pass `0` to skip minting fees (for special cases or admin operations).
@@ -156,6 +157,7 @@ public fun mint(
     proof: vector<vector<u8>>,
     height: u64,
     tx_index: u64,
+    _payload: vector<u8>,
     ops_arg: u32,
     ctx: &mut TxContext,
 ) {
@@ -191,7 +193,8 @@ public fun mint(
                 recipient = address::from_bytes(msg_reader.read(32));
             };
 
-            // stream not end, format is invalid, move data to fallback
+            // For flag=0x0 we expect only 32 bytes. If the stream is longer (more data), then
+            // the format is invalid, so moving recipient to fallback.
             if (!msg_reader.end_stream()) {
                 recipient = contract.get_fallback_addr();
             }

--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -157,6 +157,8 @@ public fun mint(
     proof: vector<vector<u8>>,
     height: u64,
     tx_index: u64,
+    // TODO: The `payload` parameter is reserved for future use related to advanced op_return instruction handling.
+    //       Implementation pending. Do not remove; will be used to support additional minting logic.
     _payload: vector<u8>,
     ops_arg: u32,
     ctx: &mut TxContext,

--- a/nBTC/tests/nbtc_tests.move
+++ b/nBTC/tests/nbtc_tests.move
@@ -48,7 +48,7 @@ fun mint_and_assert(
 ) {
     let TestData { tx_bytes, proof, height, tx_index, expected_recipient, expected_amount } = data;
 
-    nbtc::mint(ctr, lc, tx_bytes, proof, height, tx_index, ops_arg, scenario.ctx());
+    nbtc::mint(ctr, lc, tx_bytes, proof, height, tx_index, vector[], ops_arg, scenario.ctx());
     test_scenario::next_tx(scenario, sender);
 
     let coin = take_from_address<Coin<NBTC>>(scenario, expected_recipient);
@@ -181,6 +181,7 @@ fun test_nbtc_mint_fail_amount_is_zero() {
         data.proof,
         data.height,
         data.tx_index,
+        vector[],
         0,
         scenario.ctx(),
     );
@@ -205,6 +206,7 @@ fun test_nbtc_mint_fail_tx_already_used() {
         data.proof,
         data.height,
         data.tx_index,
+        vector[],
         0,
         scenario.ctx(),
     );
@@ -217,6 +219,7 @@ fun test_nbtc_mint_fail_tx_already_used() {
         data.proof,
         data.height,
         data.tx_index,
+        vector[],
         0,
         scenario.ctx(),
     );


### PR DESCRIPTION
## Description

To make future proof contract, we need to have stable API. To handle `op_return` with flags != 0 (the one that we use now), we need to be able to add a payload.

## Summary by Sourcery

Add a payload argument to the nBTC mint function to support handling op_return payloads and update related documentation and comments

New Features:
- Introduce a new `payload` parameter in the `mint` function signature and its documentation to enable op_return payload support

Enhancements:
- Refine comment logic for flag=0x0 handling by clarifying invalid stream fallback behavior