### PR TITLE
fix: update Makefile build target

### DIFF
--- a/Makefile-common.mk
+++ b/Makefile-common.mk
@@ -20,7 +20,7 @@ lint-fix-all:
 ##                              Build & Test                                 ##
 ###############################################################################
 
-build: .git/hooks/pre-commit
+build: ../.git/hooks/pre-commit
 	@sui move build
 
 test:
@@ -29,7 +29,7 @@ test:
 test-coverage:
 	sui move test --gas-limit 5000000 --coverage
 
-.PHONY: test test-coverage
+.PHONY: test test-coverage build
 
 
 ###############################################################################
@@ -53,4 +53,3 @@ gen-docs:
 ##                                Infrastructure                             ##
 ###############################################################################
 
-# To setup bitcoin, use Native Relayer.


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Fix the Makefile build target to reference the correct pre-commit hook path and declare the build target as phony

Build:
- Correct the build target dependency path to ../.git/hooks/pre-commit
- Add build to .PHONY in Makefile-common.mk