### PR TITLE
feat: nBTC redeem PoC and utxo management

### DIFF
--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -138,7 +138,7 @@ public struct RedeemRequest has store {
     status: RedeemStatus,
     amount: u64,
     inputs: vector<Utxo>,
-    reminder_output: Utxo,
+    remainder_output: Utxo,
 }
 
 /// MintEvent is emitted when nBTC is successfully minted.


### PR DESCRIPTION
## Description

Closes: #165
Superseeds: https://github.com/gonative-cc/sui-native/pull/162

## Summary by Sourcery

Add proof-of-concept for UTXO tracking and redeem request handling in the nBTC contract

New Features:
- Track UTXOs in contract storage via Utxo struct, utxos table, and next_utxo counter
- Include utxo index in MintEvent and record UTXO on each mint
- Introduce RedeemRequest struct and RedeemStatus enum with redeem_requests table and next_redeem_req counter

## Summary by Sourcery

Add proof-of-concept for UTXO tracking and redeem request management in the nBTC contract

New Features:
- Introduce Utxo struct and utxos table with next_utxo counter to store and index unspent transaction outputs
- Extend MintEvent to record UTXO index and Bitcoin transaction ID on mint
- Introduce RedeemRequest struct and redeem_requests table with next_redeem_req counter and RedeemStatus enum for handling redemption flows