### PR TITLE
feat(nbtc): add SPV-based confirm_redeem and finalize accounting

### DIFF
--- a/nBTC/sources/redeem_request.move
+++ b/nBTC/sources/redeem_request.move
@@ -77,10 +77,11 @@ public struct RequestSignatureEvent has copy, drop {
     input_idx: u32,
 }
 
+//TODO: Maybe we should refactor to have a generic RedeemReqStatusEvent
 /// Event emitted when a redeem request is confirmed on Bitcoin network.
 public struct ConfirmedEvent has copy, drop {
     id: u64,
-    tx_id: vector<u8>,
+    btc_tx_id: vector<u8>,
 }
 
 // ========== RedeemStatus methods ================
@@ -156,7 +157,7 @@ public(package) fun move_to_confirmed_status(
     //TODO: Review what to emit for this event
     event::emit(ConfirmedEvent {
         id: redeem_id,
-        tx_id: tx_id,
+        btc_tx_id: tx_id,
     });
 }
 


### PR DESCRIPTION
Using SPV for verfication that tx for redeem id was confirmed on btc network, and unlocking + removing UTXOs from table + burning nbtc after checks of confirmation are successful 

## Description

Closes: #252 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Add on-chain confirmation flow for nBTC redeem requests using Bitcoin SPV verification and finalize accounting once confirmed.

New Features:
- Introduce a confirm_redeem entry point that verifies a signed Bitcoin redeem transaction via the configured SPV light client before finalizing the redeem.
- Finalize confirmed redeems by unlocking and removing spent UTXOs, burning the corresponding nBTC, optionally registering change UTXOs, and updating redeem status to Confirmed.
- Emit a ConfirmedEvent when a redeem request is confirmed on the Bitcoin network, including redeem id, spent inputs, and tx id.