### PR TITLE
refactor(nBTC): unify redeem request status into generic event

### DIFF
--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -159,12 +159,6 @@ public struct RedeemRequestEvent has copy, drop {
     created_at: u64,
 }
 
-public struct RedeemSigCreatedEvent has copy, drop {
-    redeem_id: u64,
-    input_idx: u32,
-    is_fully_signed: bool,
-}
-
 // TODO: consider moving it to redeem_request.move
 public struct RedeemRequestProposeEvent has copy, drop {
     redeem_id: u64,
@@ -614,11 +608,7 @@ public fun validate_signature(
     r.validate_signature(dwallet_coordinator, &contract.storage, input_idx, sign_id);
 
     let is_fully_signed = r.status().is_signed();
-    event::emit(RedeemSigCreatedEvent {
-        redeem_id,
-        input_idx,
-        is_fully_signed,
-    });
+    redeem_request::emit_signature_validated_event(redeem_id, input_idx, is_fully_signed);
 }
 
 //TODO: update event emitted to include the data from the redeem request


### PR DESCRIPTION
https://github.com/gonative-cc/sui-native/pull/255#discussion_r2623554205

Closes: #260 

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Refactor redeem request lifecycle events into a single generic status event covering all key status transitions.

New Features:
- Introduce a unified RedeemReqStatusEvent to represent redeem request status changes including resolving, signing, signed, and confirmed states.

Enhancements:
- Replace multiple specific redeem-related events with the generic RedeemReqStatusEvent emitted on signing, confirmation, and signature validation.
- Add a helper to convert RedeemStatus to a numeric code for use in events and centralize signature validation event emission in the redeem_request module.