### PR TITLE
feat: remove ika sig validation

### DIFF
--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -630,7 +630,7 @@ public fun record_signature(
     let r = &mut contract.redeem_requests[redeem_id];
     assert!(!r.has_signature(input_id), EInputAlreadyUsed);
 
-    r.record_signature(dwallet_coordinator, &contract.storage, input_id, sign_id);
+    r.record_signature(dwallet_coordinator, input_id, sign_id);
 
     let is_fully_signed = r.status().is_signed();
     event::emit(RedeemSigCreatedEvent {

--- a/nBTC/sources/redeem_request.move
+++ b/nBTC/sources/redeem_request.move
@@ -23,8 +23,6 @@ use fun vector_slice as vector.slice;
 const ERedeemTxSigningNotCompleted: vector<u8> =
     b"The signature for the redeem has not been completed";
 #[error]
-const ESignatureInValid: vector<u8> = b"signature invalid for this input";
-#[error]
 const EInvalidSignatureId: vector<u8> = b"invalid signature id for redeem request";
 #[error]
 const EInvalidIkaECDSALength: vector<u8> = b"invalid ecdsa signature length from ika format";
@@ -382,13 +380,11 @@ public fun fee(r: &RedeemRequest): u64 { r.fee }
 public(package) fun record_signature(
     r: &mut RedeemRequest,
     dwallet_coordinator: &DWalletCoordinator,
-    storage: &Storage,
     input_id: u32,
     sign_id: ID,
 ) {
     // TODO: ensure we get right spend key, because this spend key can also inactive_spend_key
     assert!(r.sign_ids.contains(sign_id), EInvalidSignatureId);
-    let sign_hash = r.sig_hash(input_id, storage);
     let dwallet_id = r.dwallet_ids[input_id as u64];
     let signature = get_signature(dwallet_coordinator, dwallet_id, sign_id);
     // NOTE: We intentionally do not re-verify the signature on-chain here.

--- a/nBTC/tests/redeem_workflow_tests.move
+++ b/nBTC/tests/redeem_workflow_tests.move
@@ -301,7 +301,7 @@ fun test_cannot_propose_overlapping_locked_utxos() {
 
 #[test]
 fun test_confirm_redeem_burns_nbtc_and_removes_utxos() {
-    let (mut lc, mut ctr, redeem_id, dwallet_id, mut scenario, clock) = setup_redeem_test(
+    let (mut lc, mut ctr, redeem_id, dwallet_id, scenario, clock) = setup_redeem_test(
         2500,
         1000,
         NBTC_P2WPKH_SCRIPT,
@@ -348,7 +348,7 @@ fun test_confirm_redeem_burns_nbtc_and_removes_utxos() {
 
 #[test]
 fun test_confirm_redeem_no_change() {
-    let (mut lc, mut ctr, redeem_id, dwallet_id, mut scenario, clock) = setup_redeem_test(
+    let (mut lc, mut ctr, redeem_id, dwallet_id, scenario, clock) = setup_redeem_test(
         1000,
         1000,
         NBTC_P2WPKH_SCRIPT,


### PR DESCRIPTION
## Description

Related to #268

## Summary by Sourcery

Enhancements:
- Simplify redeem request signature recording by omitting direct secp256k1 signature validation.