### PR TITLE
feat(nbtc): don't fail if ika sig was already recorded - do early return

### DIFF
--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -608,7 +608,8 @@ public fun finalize_redeem(
 // TODO: we should be able to record many signatures in a single tx
 /// Try to read sig from dwallet and save it in the inputs store.
 /// Fails if the sig is not available. Validation is left on the Ika side.
-/// Returns true if sig is recorded, false if sig was already recorded before.
+/// Returns true if sig is recorded, false if sig was already recorded before and aborts if
+/// the validation fails.
 public fun record_signature(
     contract: &mut NbtcContract,
     dwallet_coordinator: &DWalletCoordinator,


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Make signature recording on nBTC redeem requests idempotent and report whether a signature was newly recorded or already present.

Bug Fixes:
- Avoid failing when attempting to record a signature that has already been stored for a given redeem input.

Enhancements:
- Change the signature recording function to return a boolean indicating whether a signature was recorded.