### PR TITLE
fix(nbtc): remove from table to avoid inactive balance drain

### DIFF
--- a/nBTC/sources/storage.move
+++ b/nBTC/sources/storage.move
@@ -171,9 +171,7 @@ public(package) fun remove_inactive_deposit(
     user: address,
 ): u64 {
     let d = store.dwallet_mut(dwallet_id);
-    let user_balance = &mut d.inactive_deposits.remove(user);
-    let amount = *user_balance;
-    *user_balance = 0;
+    let amount = d.inactive_deposits.remove(user);
     d.total_deposit = d.total_deposit - amount;
     amount
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure inactive deposit entries are fully removed from the dwallet map instead of leaving a zeroed balance that could be drained.