### PR TITLE
refactor(nbtc): don't use table for config

### DIFF
--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -735,13 +735,11 @@ public fun change_fees(_: &AdminCap, contract: &mut NbtcContract, mint_fee: u64)
     contract.config.set_mint_fee(mint_fee);
 }
 
-/// Sets config for specific NBTC version.
-/// This should be called by the admin before updating the package with the next package_version
 public fun update_config(contract: &mut NbtcContract, _: &AdminCap, config: Config) {
     contract.config = config;
 }
 
-/// Set a metadata for dwallet
+/// Registers a new dwallet with it's bitcoin spending script.
 /// BTC lockscript must derive from dwallet public key which is control by dwallet_cap.
 public fun add_dwallet(
     _: &AdminCap,


### PR DESCRIPTION
## Summary by Sourcery

Simplify NBTC contract configuration by storing a single Config object instead of a versioned table and updating all usages accordingly.

Enhancements:
- Replace table-based, versioned configuration with a single Config field on NbtcContract and thread it through initialization and test helpers.
- Update configuration accessors and mutators to work on the direct Config field, including fee, redeem duration, and light client checks.
- Simplify the admin config update flow so that set_config replaces the current Config rather than adding a new versioned entry.