### PR TITLE
refactor(nbtc tests): centralize constants and setup helper

### DIFF
--- a/nBTC/tests/nbtc_tests.move
+++ b/nBTC/tests/nbtc_tests.move
@@ -9,7 +9,7 @@ use ika_dwallet_2pc_mpc::coordinator::{coordinator_for_test, DWalletCoordinator}
 use ika_dwallet_2pc_mpc::coordinator_inner::{dwallet_coordinator_internal, dwallet_cap_for_testing};
 use nbtc::nbtc::{Self, NbtcContract, EMintAmountIsZero, ETxAlreadyUsed, EAlreadyUpdated, NBTC};
 use nbtc::storage::{Self, BtcDWallet};
-use nbtc::test_constants::MOCK_DWALLET_ID;
+use nbtc::test_constants::{MOCK_DWALLET_ID, NBTC_SCRIPT_PUBKEY, FALLBACK_ADDR};
 use std::unit_test::{assert_eq, destroy};
 use sui::address;
 use sui::coin::Coin;
@@ -17,8 +17,6 @@ use sui::test_scenario::{Self, take_from_address, Scenario};
 
 // The fallback Sui address to receive nBTC if OP_RETURN data is invalid or missing.
 // Use for test
-const FALLBACK_ADDR: address = @0xB0B;
-const NBTC_SCRIPT_PUBKEY: vector<u8> = x"76a914509a651dd392e1bc125323f629b67d65cca3d4bb88ac";
 
 // copy from nbtc.move
 const MINT_OP_APPLY_FEE: u32 = 1;
@@ -81,7 +79,7 @@ fun get_fallback_mint_data(): TestData {
         proof: vector[x"514956dad9c4d52fbdb3ae846646d1ad1ba34587dee9c82a291447a9f9909061"], // pre-image: single sha256 over the tx_2
         height: 0,
         tx_index: 0,
-        expected_recipient: FALLBACK_ADDR,
+        expected_recipient: FALLBACK_ADDR!(),
         expected_amount: 100_000_000,
     }
 }
@@ -120,7 +118,7 @@ public fun setup_with_dwallet(
     let lc = new_light_client(bitcoin_spv::params::regtest(), 0, headers, 0, 1, scenario.ctx());
     let mut ctr = nbtc::init_for_testing(
         lc.client_id().to_address(),
-        FALLBACK_ADDR,
+        FALLBACK_ADDR!(),
         coordinator_id,
         scenario.ctx(),
     );
@@ -151,7 +149,7 @@ public fun setup(
 fun test_nbtc_mint() {
     let sender = @0x1;
     let (lc, mut ctr, dwallet_coordinator, mut scenario) = setup(
-        NBTC_SCRIPT_PUBKEY,
+        NBTC_SCRIPT_PUBKEY!(),
         sender,
         MOCK_DWALLET_ID!(),
     );
@@ -188,7 +186,7 @@ fun test_nbtc_mint() {
 fun test_mint_with_fee() {
     let sender = @0x1;
     let (lc, mut ctr, dwallet_coordinator, mut scenario) = setup(
-        NBTC_SCRIPT_PUBKEY,
+        NBTC_SCRIPT_PUBKEY!(),
         sender,
         MOCK_DWALLET_ID!(),
     );
@@ -259,7 +257,7 @@ fun test_nbtc_mint_fail_amount_is_zero() {
 fun test_nbtc_mint_fail_tx_already_used() {
     let sender = @0x1;
     let (lc, mut ctr, dwallet_coordinator, mut scenario) = setup(
-        NBTC_SCRIPT_PUBKEY,
+        NBTC_SCRIPT_PUBKEY!(),
         sender,
         object::id_from_address(@0x01),
     );
@@ -299,7 +297,7 @@ fun test_nbtc_mint_fail_tx_already_used() {
 fun test_update_version_fail() {
     let sender = @0x01;
     let (_lc, mut ctr, _dwallet_coordinator, _scenario) = setup(
-        NBTC_SCRIPT_PUBKEY,
+        NBTC_SCRIPT_PUBKEY!(),
         sender,
         object::id_from_address(@0x01),
     );

--- a/nBTC/tests/record_signature_tests.move
+++ b/nBTC/tests/record_signature_tests.move
@@ -9,16 +9,17 @@ use ika_dwallet_2pc_mpc::coordinator::{
 use nbtc::nbtc::NBTC;
 use nbtc::nbtc_tests::setup;
 use nbtc::nbtc_utxo::new_utxo;
-use nbtc::test_constants::MOCK_DWALLET_ID;
+use nbtc::test_constants::{
+    MOCK_DWALLET_ID,
+    NBTC_SCRIPT_PUBKEY,
+    ADMIN,
+    RECEIVER_SCRIPT,
+    TX_HASH,
+    REDEEM_FEE
+};
 use std::unit_test::{assert_eq, destroy};
 use sui::clock;
 use sui::coin::mint_for_testing;
-
-const NBTC_SCRIPT_PUBKEY: vector<u8> = x"76a914509a651dd392e1bc125323f629b67d65cca3d4bb88ac";
-const ADMIN: address = @0xad;
-const RECEIVER_SCRIPT: vector<u8> = x"0014000000000000000000000000000000000000000002";
-const TX_HASH: vector<u8> = x"06ce677fd511851bb6cdacebed863d12dfd231d810e8e9fcba6e791001adf3a6";
-const REDEEM_FEE: u64 = 150;
 
 const MOCK_SIGNATURE: vector<u8> =
     x"b693a0797b24bae12ed0516a2f5ba765618dca89b75e498ba5b745b71644362298a45ca39230d10a02ee6290a91cebf9839600f7e35158a447ea182ea0e022ae";
@@ -42,21 +43,27 @@ fun setup_redeem_in_signing_state(
 
     // Setup nBTC contract first to get scenario
     let (lc, mut ctr, mut dwallet_coordinator, mut scenario) = setup(
-        NBTC_SCRIPT_PUBKEY,
-        ADMIN,
+        NBTC_SCRIPT_PUBKEY!(),
+        ADMIN!(),
         dwallet_id,
     );
 
     // Create real DWalletCoordinator with inner state
     // The coordinator is already returned by setup with dwallet added
 
-    let utxo = new_utxo(TX_HASH, 0, utxo_amount, dwallet_id);
+    let utxo = new_utxo(TX_HASH!(), 0, utxo_amount, dwallet_id);
     ctr.add_utxo_for_test(0, utxo);
 
     let nbtc_coin = ctr.testing_mint(redeem_amount, scenario.ctx());
 
     let mut clock = clock::create_for_testing(scenario.ctx());
-    let redeem_id = ctr.redeem(nbtc_coin, RECEIVER_SCRIPT, REDEEM_FEE, &clock, scenario.ctx());
+    let redeem_id = ctr.redeem(
+        nbtc_coin,
+        RECEIVER_SCRIPT!(),
+        REDEEM_FEE!(),
+        &clock,
+        scenario.ctx(),
+    );
 
     // Move to signing state
     ctr.propose_utxos(redeem_id, vector[0], &clock);
@@ -237,7 +244,7 @@ fun test_record_signature_event_emission() {
     assert_eq!(results1[0], true);
 
     // Move to next transaction to check events
-    scenario.next_tx(ADMIN);
+    scenario.next_tx(ADMIN!());
 
     // Second call - should NOT emit event (early return)
     let results2 = ctr.record_signature(
@@ -260,15 +267,15 @@ fun test_record_signature_event_emission() {
 fun test_record_signature_with_multiple_inputs() {
     let dwallet_id = MOCK_DWALLET_ID!();
     let (lc, mut ctr, mut dwallet_coordinator, mut scenario) = setup(
-        NBTC_SCRIPT_PUBKEY,
-        ADMIN,
+        NBTC_SCRIPT_PUBKEY!(),
+        ADMIN!(),
         dwallet_id,
     );
 
     // Add dwallet to coordinator is already done in setup
 
     // Add two UTXOs
-    let utxo1 = new_utxo(TX_HASH, 0, 1000, dwallet_id);
+    let utxo1 = new_utxo(TX_HASH!(), 0, 1000, dwallet_id);
     ctr.add_utxo_for_test(0, utxo1);
 
     let utxo2 = new_utxo(
@@ -281,7 +288,13 @@ fun test_record_signature_with_multiple_inputs() {
 
     let nbtc_coin = mint_for_testing<NBTC>(1500, scenario.ctx());
     let mut clock = clock::create_for_testing(scenario.ctx());
-    let redeem_id = ctr.redeem(nbtc_coin, RECEIVER_SCRIPT, REDEEM_FEE, &clock, scenario.ctx());
+    let redeem_id = ctr.redeem(
+        nbtc_coin,
+        RECEIVER_SCRIPT!(),
+        REDEEM_FEE!(),
+        &clock,
+        scenario.ctx(),
+    );
 
     // Move to signing state with both UTXOs
     ctr.propose_utxos(redeem_id, vector[0, 1], &clock);
@@ -350,15 +363,15 @@ fun test_record_signature_with_multiple_inputs() {
 fun test_record_signature_batch() {
     let dwallet_id = MOCK_DWALLET_ID!();
     let (lc, mut ctr, mut dwallet_coordinator, mut scenario) = setup(
-        NBTC_SCRIPT_PUBKEY,
-        ADMIN,
+        NBTC_SCRIPT_PUBKEY!(),
+        ADMIN!(),
         dwallet_id,
     );
 
     // Add dwallet to coordinator is already done in setup
 
     // Add two UTXOs
-    let utxo1 = new_utxo(TX_HASH, 0, 1000, dwallet_id);
+    let utxo1 = new_utxo(TX_HASH!(), 0, 1000, dwallet_id);
     ctr.add_utxo_for_test(0, utxo1);
 
     let utxo2 = new_utxo(
@@ -371,7 +384,13 @@ fun test_record_signature_batch() {
 
     let nbtc_coin = mint_for_testing<NBTC>(1500, scenario.ctx());
     let mut clock = clock::create_for_testing(scenario.ctx());
-    let redeem_id = ctr.redeem(nbtc_coin, RECEIVER_SCRIPT, REDEEM_FEE, &clock, scenario.ctx());
+    let redeem_id = ctr.redeem(
+        nbtc_coin,
+        RECEIVER_SCRIPT!(),
+        REDEEM_FEE!(),
+        &clock,
+        scenario.ctx(),
+    );
 
     // Move to signing state with both UTXOs
     ctr.propose_utxos(redeem_id, vector[0, 1], &clock);

--- a/nBTC/tests/test_constants.move
+++ b/nBTC/tests/test_constants.move
@@ -10,3 +10,29 @@ public macro fun MOCK_DWALLET_ID(): ID {
 public macro fun MOCK_DWALLET_ID_2(): ID {
     object::id_from_address(@0x02)
 }
+
+// Fallback address for receiving nBTC if OP_RETURN data is invalid or missing
+public macro fun FALLBACK_ADDR(): address {
+    @0xB0B
+}
+
+// Common test constants - as public macros
+public macro fun NBTC_SCRIPT_PUBKEY(): vector<u8> {
+    x"76a914509a651dd392e1bc125323f629b67d65cca3d4bb88ac"
+}
+
+public macro fun ADMIN(): address {
+    @0xad
+}
+
+public macro fun TX_HASH(): vector<u8> {
+    x"06ce677fd511851bb6cdacebed863d12dfd231d810e8e9fcba6e791001adf3a6"
+}
+
+public macro fun REDEEM_FEE(): u64 {
+    150
+}
+
+public macro fun RECEIVER_SCRIPT(): vector<u8> {
+    x"00140000000000000000000000000000000000000002"
+}


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Consolidate shared nBTC test constants and setup helpers into reusable macros and functions, and update redeem and record signature tests to use the new centralized test helpers.

Enhancements:
- Replace inline test constants in nBTC tests with shared public macros from test_constants for script pubkey, admin address, receiver script, tx hash, redeem fee, and fallback address.
- Rename and generalize the nbtc test setup helper to setup_with_dwallet and adjust callers accordingly to better reflect its purpose.