### PR TITLE
feat(nbtc): simplify inactive_dwallet

### DIFF
--- a/nBTC/sources/storage.move
+++ b/nBTC/sources/storage.move
@@ -166,7 +166,6 @@ public fun active_dwallet(store: &Storage, dwallet_id: ID): &BtcDWallet {
 /// Returns an inactive dwallet by ID.
 /// Aborts if dwallet is not inactive.
 public fun inactive_dwallet(store: &Storage, dwallet_id: ID): &BtcDWallet {
-    assert!(store.dwallet_trash.contains(dwallet_id), EDwalletNotFound);
     &store.dwallet_trash[dwallet_id]
 }
 


### PR DESCRIPTION
## Description

We don't need to call 2 Sui storage access. We can do one only.

## Summary by Sourcery

Enhancements:
- Streamline inactive dWallet lookup to avoid redundant storage existence checks before access.