### PR TITLE
feat(nbtc): add UTXO migration flow between dwallets

### DIFF
--- a/nBTC/sources/nbtc.move
+++ b/nBTC/sources/nbtc.move
@@ -84,6 +84,8 @@ const ERedeemTxNotConfirmed: vector<u8> = b"Bitcoin redeem tx not confirmed via 
 #[error]
 const EInputSignIdLengthMismatch: vector<u8> =
     b"input_ids and sign_ids vectors must have the same length";
+#[error]
+const ENotMigrationRequest: vector<u8> = b"redeem request is not a migration request";
 
 //
 // Structs
@@ -177,6 +179,22 @@ public struct BurnEvent has copy, drop {
     amount: u64,
     /// Bitcoin withdraw TX ID
     tx_id: vector<u8>,
+}
+
+public struct MigrationRequestEvent has copy, drop {
+    redeem_id: u64,
+    utxo_ids: vector<u64>,
+    amount: u64,
+    fee: u64,
+    created_at: u64,
+    target_dwallet_id: ID,
+}
+
+public struct MigrationFinalizedEvent has copy, drop {
+    redeem_id: u64,
+    tx_id: vector<u8>,
+    migrated_amount: u64,
+    target_dwallet_id: ID,
 }
 
 //
@@ -593,6 +611,7 @@ public fun finalize_redeem(
 
     let mut r = contract.redeem_requests.remove(redeem_id);
     assert!(r.status().is_signed(), ENotSigned);
+    assert!(!r.is_migration(), ENotMigrationRequest);
 
     let tx_id = r.btc_tx_id();
     assert!(light_client.verify_tx(height, tx_id, proof, tx_index), ERedeemTxNotConfirmed);
@@ -847,6 +866,115 @@ public fun deactivate_dwallet(_: &AdminCap, contract: &mut NbtcContract, dwallet
     contract.storage.deactivate_dwallet(dwallet_id);
 }
 
+public fun migrate_utxos(
+    _: &AdminCap,
+    contract: &mut NbtcContract,
+    utxo_ids: vector<u64>,
+    fee: u64,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): u64 {
+    assert!(contract.version == VERSION, EVersionMismatch);
+
+    let mut total_value: u64 = 0;
+    utxo_ids.length().do!(|i| {
+        let idx = utxo_ids[i];
+        let utxo = contract.storage.utxo_store().get_utxo(idx);
+        total_value = total_value + utxo.value();
+    });
+
+    let recommended_dwallet = contract.storage.recommended_dwallet();
+    let target_lockscript = recommended_dwallet.lockscript();
+    let target_dwallet_id = recommended_dwallet.dwallet_id();
+
+    let redeem_id = contract.next_redeem_req;
+    contract.next_redeem_req = redeem_id + 1;
+
+    let mut r = redeem_request::new_migration(
+        target_lockscript,
+        ctx.sender(),
+        total_value,
+        fee,
+        clock.timestamp_ms(),
+        ctx,
+    );
+
+    r.set_utxos(utxo_ids);
+
+    utxo_ids.length().do!(|i| {
+        nbtc_utxo::lock_utxo(
+            contract.storage.utxo_store_mut(),
+            utxo_ids[i],
+            redeem_id,
+        );
+    });
+
+    event::emit(MigrationRequestEvent {
+        redeem_id,
+        utxo_ids,
+        amount: total_value,
+        fee,
+        created_at: r.redeem_created_at(),
+        target_dwallet_id,
+    });
+
+    contract.redeem_requests.add(redeem_id, r);
+
+    redeem_id
+}
+
+public fun finalize_migration(
+    contract: &mut NbtcContract,
+    light_client: &LightClient,
+    redeem_id: u64,
+    proof: vector<vector<u8>>,
+    height: u64,
+    tx_index: u64,
+) {
+    assert!(contract.version == VERSION, EVersionMismatch);
+    contract.assert_light_client(object::id(light_client));
+
+    let mut r = contract.redeem_requests.remove(redeem_id);
+    assert!(r.status().is_signed(), ENotSigned);
+    assert!(r.is_migration(), ENotMigrationRequest);
+
+    let tx_id = r.btc_tx_id();
+    assert!(light_client.verify_tx(height, tx_id, proof, tx_index), ERedeemTxNotConfirmed);
+
+    let spent_utxos_ids = r.utxo_ids();
+
+    spent_utxos_ids.length().do!(|i| {
+        nbtc_utxo::unlock_utxo(
+            contract.storage.utxo_store_mut(),
+            spent_utxos_ids[i],
+        );
+    });
+
+    r.burn_utxos();
+
+    let outputs = r.outputs();
+    let recommended_dwallet_id = contract.storage.recommended_dwallet().dwallet_id();
+    let migrated_amount = r.amount() - r.fee();
+
+    let migration_output = &outputs[0];
+    let migration_utxo = nbtc_utxo::new_utxo(
+        tx_id,
+        0,
+        migration_output.amount(),
+        recommended_dwallet_id,
+    );
+    contract.storage.utxo_store_mut().add(migration_utxo);
+
+    event::emit(MigrationFinalizedEvent {
+        redeem_id,
+        tx_id,
+        migrated_amount,
+        target_dwallet_id: recommended_dwallet_id,
+    });
+
+    r.destroy_confirmed();
+}
+
 public(package) fun add_utxo_to_contract(
     contract: &mut NbtcContract,
     tx_id: vector<u8>,
@@ -987,6 +1115,11 @@ public fun set_dwallet_for_test(contract: &mut NbtcContract, dw: BtcDWallet) {
 }
 
 #[test_only]
+public fun deactivate_dwallet_for_test(contract: &mut NbtcContract, dwallet_id: ID) {
+    contract.storage.deactivate_dwallet(dwallet_id);
+}
+
+#[test_only]
 /// Helper functions to access event fields in tests
 public fun get_redeem_sig_created_event_redeem_id(event: &RedeemSigCreatedEvent): u64 {
     event.redeem_id
@@ -1010,4 +1143,47 @@ public fun get_redeem_withdraw_ready_event_tx_id(event: &RedeemWithdrawReadyEven
 #[test_only]
 public fun get_redeem_withdraw_ready_event_tx_raw(event: &RedeemWithdrawReadyEvent): vector<u8> {
     event.tx_raw
+}
+
+#[test_only]
+public fun create_migration_request_for_testing(
+    contract: &mut NbtcContract,
+    redeem_id: u64,
+    redeemer: address,
+    amount: u64,
+    fee: u64,
+    created_at: u64,
+    ctx: &mut TxContext,
+) {
+    let recommended_dwallet = contract.storage.recommended_dwallet();
+    let target_lockscript = recommended_dwallet.lockscript();
+    let r = redeem_request::new_migration(
+        target_lockscript,
+        redeemer,
+        amount,
+        fee,
+        created_at,
+        ctx,
+    );
+    contract.redeem_requests.add(redeem_id, r);
+}
+
+#[test_only]
+public fun get_migration_finalized_event_redeem_id(event: &MigrationFinalizedEvent): u64 {
+    event.redeem_id
+}
+
+#[test_only]
+public fun get_migration_finalized_event_tx_id(event: &MigrationFinalizedEvent): vector<u8> {
+    event.tx_id
+}
+
+#[test_only]
+public fun get_migration_finalized_event_migrated_amount(event: &MigrationFinalizedEvent): u64 {
+    event.migrated_amount
+}
+
+#[test_only]
+public fun get_migration_finalized_event_target_dwallet_id(event: &MigrationFinalizedEvent): ID {
+    event.target_dwallet_id
 }

--- a/nBTC/sources/redeem_request.move
+++ b/nBTC/sources/redeem_request.move
@@ -59,6 +59,7 @@ public struct RedeemRequest has store {
     signatures: vector<vector<u8>>,
     created_at: u64,
     signed_input: u64,
+    is_migration: bool,
 }
 
 /// Event emitted when a proposal for redeem request is selected (solved) and we are ready
@@ -482,6 +483,36 @@ public fun new(
         created_at,
         signed_input: 0,
         nbtc_dwallet_id,
+        is_migration: false,
+    }
+}
+
+public(package) fun new_migration(
+    nbtc_spend_script: vector<u8>,
+    redeemer: address,
+    total_value: u64,
+    fee: u64,
+    created_at: u64,
+    ctx: &mut TxContext,
+): RedeemRequest {
+    RedeemRequest {
+        nbtc_spend_script,
+        redeemer,
+        recipient_script: nbtc_spend_script,
+        amount: total_value,
+        sig_hashes: vector::empty(),
+        fee,
+        utxos: vector::empty(),
+        sign_ids: table::new(ctx),
+        signatures: vector::empty(),
+        status: RedeemStatus::Resolving,
+        utxo_ids: vector::empty(),
+        btc_tx_id: vector::empty(),
+        outputs: vector::empty(),
+        created_at,
+        signed_input: 0,
+        nbtc_dwallet_id: @0x0.to_id(),
+        is_migration: true,
     }
 }
 
@@ -493,6 +524,8 @@ public fun utxo_at(r: &RedeemRequest, i: u64): &Utxo {
 }
 
 public fun fee(r: &RedeemRequest): u64 { r.fee }
+
+public fun is_migration(r: &RedeemRequest): bool { r.is_migration }
 
 public(package) fun record_signature(
     r: &mut RedeemRequest,
@@ -546,6 +579,7 @@ public(package) fun destroy_confirmed(r: RedeemRequest) {
         signatures: _,
         created_at: _,
         signed_input: _,
+        is_migration: _,
     } = r;
     utxos.destroy_empty();
     sign_ids.drop();

--- a/nBTC/sources/tx_composer.move
+++ b/nBTC/sources/tx_composer.move
@@ -26,17 +26,15 @@ public fun compose_withdraw_tx(
         let inp = input::new(
             utxo.tx_id(),
             u32_to_le_bytes(utxo.vout()),
-            vector::empty(), // Because utxos is segwit format so script_sig field is empty
+            vector::empty(),
             DEFAULT_SEQUENCE,
         );
         inps.push_back(inp);
     });
 
-    // user cover the fee
     let user_receive_amount = withdraw_amount - fee;
     let remain_amount = total_spend - withdraw_amount;
 
-    // output for for receiver
     let mut outs = vector[output::new(user_receive_amount, recipient_script)];
 
     if (remain_amount > 0) {

--- a/nBTC/tests/migration_tests.move
+++ b/nBTC/tests/migration_tests.move
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#[test_only]
+module nbtc::migration_tests;
+
+use bitcoin_spv::light_client::LightClient;
+use ika_dwallet_2pc_mpc::coordinator_inner::dwallet_cap_for_testing;
+use nbtc::nbtc::{Self, NbtcContract, AdminCap};
+use nbtc::nbtc_tests;
+use nbtc::nbtc_utxo::new_utxo;
+use nbtc::redeem_request::{update_to_signed_for_test, is_migration};
+use nbtc::storage;
+use nbtc::test_constants::{
+    MOCK_DWALLET_ID,
+    MOCK_DWALLET_ID_2,
+    NBTC_TAPROOT_SCRIPT,
+    ADMIN,
+    TX_HASH,
+    TX_HASH_2,
+    REDEEM_FEE,
+    MOCK_SIGNATURE
+};
+use std::string;
+use std::unit_test::{assert_eq, destroy};
+use sui::clock;
+use sui::test_scenario::Scenario;
+
+#[test_only]
+fun setup_migration_test_simple(
+    utxo_amount: u64,
+    lockscript: vector<u8>,
+): (LightClient, NbtcContract, AdminCap, ID, Scenario, clock::Clock) {
+    let recommended_dwallet_id = MOCK_DWALLET_ID!();
+
+    let mut temp_scenario = sui::test_scenario::begin(ADMIN!());
+    let recommended_dw = storage::create_dwallet(
+        dwallet_cap_for_testing(recommended_dwallet_id, temp_scenario.ctx()),
+        lockscript,
+        0,
+        vector::empty(),
+        vector::empty(),
+        vector::empty(),
+        vector::empty(),
+        string::utf8(b"tb1qrecommended"),
+        temp_scenario.ctx(),
+    );
+    temp_scenario.end();
+
+    let (lc, mut ctr, _dwallet_coordinator, mut scenario) = nbtc_tests::setup_with_dwallet(
+        ADMIN!(),
+        recommended_dwallet_id,
+        recommended_dw,
+    );
+
+    let admin_cap = nbtc::admin_cap_for_testing(scenario.ctx());
+
+    let utxo = new_utxo(TX_HASH!(), 0, utxo_amount, recommended_dwallet_id);
+    ctr.add_utxo_for_test(0, utxo);
+
+    let clock = clock::create_for_testing(scenario.ctx());
+
+    destroy(_dwallet_coordinator);
+    (lc, ctr, admin_cap, recommended_dwallet_id, scenario, clock)
+}
+
+#[test]
+fun test_migrate_utxos_creates_request() {
+    let (
+        lc,
+        mut ctr,
+        admin_cap,
+        _recommended_dwallet_id,
+        mut scenario,
+        clock,
+    ) = setup_migration_test_simple(2500, NBTC_TAPROOT_SCRIPT!());
+
+    let redeem_id = nbtc::migrate_utxos(
+        &admin_cap,
+        &mut ctr,
+        vector[0u64],
+        REDEEM_FEE!(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let request = ctr.redeem_request(redeem_id);
+    assert_eq!(is_migration(request), true);
+    assert_eq!(request.status().is_resolving(), true);
+
+    clock.destroy_for_testing();
+    destroy(lc);
+    destroy(ctr);
+    destroy(admin_cap);
+    scenario.end();
+}
+
+#[test]
+fun test_migrate_utxos_with_multiple_utxos() {
+    let recommended_dwallet_id = MOCK_DWALLET_ID!();
+
+    let mut temp_scenario = sui::test_scenario::begin(ADMIN!());
+    let recommended_dw = storage::create_dwallet(
+        dwallet_cap_for_testing(recommended_dwallet_id, temp_scenario.ctx()),
+        NBTC_TAPROOT_SCRIPT!(),
+        0,
+        vector::empty(),
+        vector::empty(),
+        vector::empty(),
+        vector::empty(),
+        string::utf8(b"tb1qrecommended"),
+        temp_scenario.ctx(),
+    );
+    temp_scenario.end();
+
+    let (lc, mut ctr, _dwallet_coordinator, mut scenario) = nbtc_tests::setup_with_dwallet(
+        ADMIN!(),
+        recommended_dwallet_id,
+        recommended_dw,
+    );
+
+    let admin_cap = nbtc::admin_cap_for_testing(scenario.ctx());
+
+    let utxo_1 = new_utxo(TX_HASH!(), 0, 1000, recommended_dwallet_id);
+    ctr.add_utxo_for_test(0, utxo_1);
+
+    let utxo_2 = new_utxo(TX_HASH_2!(), 1, 1500, recommended_dwallet_id);
+    ctr.add_utxo_for_test(1, utxo_2);
+
+    let clock = clock::create_for_testing(scenario.ctx());
+
+    let redeem_id = nbtc::migrate_utxos(
+        &admin_cap,
+        &mut ctr,
+        vector[0u64, 1u64],
+        REDEEM_FEE!(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    let request = ctr.redeem_request(redeem_id);
+    assert_eq!(request.amount(), 2500);
+    assert_eq!(request.utxo_ids().length(), 2);
+
+    clock.destroy_for_testing();
+    destroy(lc);
+    destroy(ctr);
+    destroy(admin_cap);
+    destroy(_dwallet_coordinator);
+    scenario.end();
+}
+
+#[test, expected_failure]
+fun test_finalize_redeem_fails_for_migration_request() {
+    let (
+        mut lc,
+        mut ctr,
+        admin_cap,
+        _recommended_dwallet_id,
+        mut scenario,
+        mut clock,
+    ) = setup_migration_test_simple(2500, NBTC_TAPROOT_SCRIPT!());
+
+    let redeem_id = nbtc::migrate_utxos(
+        &admin_cap,
+        &mut ctr,
+        vector[0u64],
+        REDEEM_FEE!(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    ctr.propose_utxos(redeem_id, vector[0u64], &clock);
+    clock.increment_for_testing(ctr.redeem_duration() + 1);
+    ctr.solve_redeem_request(redeem_id, &clock);
+
+    let request_mut = ctr.redeem_request_mut(redeem_id);
+    let mock_sig = MOCK_SIGNATURE!();
+    request_mut.update_to_signed_for_test(vector[mock_sig]);
+
+    let r = ctr.redeem_request(redeem_id);
+    let tx = r.compose_tx(ctr.storage());
+    let tx_id = tx.tx_id();
+
+    let parent_hash = lc.head_hash();
+    let header = bitcoin_lib::header::create_header_for_test(
+        x"00000020",
+        parent_hash,
+        tx_id,
+        x"132ae858",
+        x"ffff7f20",
+        x"01000011",
+    );
+    lc.insert_headers(vector[header]);
+
+    ctr.finalize_redeem(&lc, redeem_id, vector[], 1, 0);
+
+    clock.destroy_for_testing();
+    destroy(lc);
+    destroy(ctr);
+    destroy(admin_cap);
+    scenario.end();
+}
+
+#[test]
+fun test_finalize_migration_creates_new_utxo() {
+    let (
+        mut lc,
+        mut ctr,
+        admin_cap,
+        recommended_dwallet_id,
+        mut scenario,
+        mut clock,
+    ) = setup_migration_test_simple(2500, NBTC_TAPROOT_SCRIPT!());
+
+    let redeem_id = nbtc::migrate_utxos(
+        &admin_cap,
+        &mut ctr,
+        vector[0u64],
+        REDEEM_FEE!(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    ctr.propose_utxos(redeem_id, vector[0u64], &clock);
+    clock.increment_for_testing(ctr.redeem_duration() + 1);
+    ctr.solve_redeem_request(redeem_id, &clock);
+
+    let request_mut = ctr.redeem_request_mut(redeem_id);
+    let mock_sig = MOCK_SIGNATURE!();
+    request_mut.update_to_signed_for_test(vector[mock_sig]);
+
+    let r = ctr.redeem_request(redeem_id);
+    let tx = r.compose_tx(ctr.storage());
+    let tx_id = tx.tx_id();
+
+    let parent_hash = lc.head_hash();
+    let header = bitcoin_lib::header::create_header_for_test(
+        x"00000020",
+        parent_hash,
+        tx_id,
+        x"132ae858",
+        x"ffff7f20",
+        x"01000011",
+    );
+    lc.insert_headers(vector[header]);
+
+    let supply_before = ctr.total_supply();
+    ctr.finalize_migration(&lc, redeem_id, vector[], 1, 0);
+    let supply_after = ctr.total_supply();
+
+    assert_eq!(supply_after, supply_before);
+
+    let utxo_store = ctr.borrow_utxo_map_for_test();
+    assert_eq!(utxo_store.contains(0), false);
+    assert_eq!(utxo_store.contains(1), true);
+
+    let new_utxo = utxo_store.get_utxo(1);
+    assert_eq!(new_utxo.dwallet_id() == recommended_dwallet_id, true);
+    assert_eq!(new_utxo.value(), 2500 - REDEEM_FEE!());
+
+    clock.destroy_for_testing();
+    destroy(lc);
+    destroy(ctr);
+    destroy(admin_cap);
+    scenario.end();
+}
+
+#[test]
+fun test_finalize_migration_and_deactivate_separate() {
+    let recommended_dwallet_id = MOCK_DWALLET_ID!();
+    let other_dwallet_id = MOCK_DWALLET_ID_2!();
+
+    let mut temp_scenario = sui::test_scenario::begin(ADMIN!());
+    let other_dw = storage::create_dwallet(
+        dwallet_cap_for_testing(other_dwallet_id, temp_scenario.ctx()),
+        NBTC_TAPROOT_SCRIPT!(),
+        0,
+        vector::empty(),
+        vector::empty(),
+        vector::empty(),
+        vector::empty(),
+        string::utf8(b"tb1qother"),
+        temp_scenario.ctx(),
+    );
+    temp_scenario.end();
+
+    let (mut lc, mut ctr, _dwallet_coordinator, mut scenario) = nbtc_tests::setup_with_dwallet(
+        ADMIN!(),
+        other_dwallet_id,
+        other_dw,
+    );
+
+    let mut temp_scenario2 = sui::test_scenario::begin(ADMIN!());
+    let recommended_dw = storage::create_dwallet(
+        dwallet_cap_for_testing(recommended_dwallet_id, temp_scenario2.ctx()),
+        NBTC_TAPROOT_SCRIPT!(),
+        0,
+        vector::empty(),
+        vector::empty(),
+        vector::empty(),
+        vector::empty(),
+        string::utf8(b"tb1qrecommended"),
+        temp_scenario2.ctx(),
+    );
+    temp_scenario2.end();
+
+    ctr.set_dwallet_for_test(recommended_dw);
+
+    let admin_cap = nbtc::admin_cap_for_testing(scenario.ctx());
+
+    let utxo = new_utxo(TX_HASH!(), 0, 2500, other_dwallet_id);
+    ctr.add_utxo_for_test(0, utxo);
+
+    let mut clock = clock::create_for_testing(scenario.ctx());
+
+    let redeem_id = nbtc::migrate_utxos(
+        &admin_cap,
+        &mut ctr,
+        vector[0u64],
+        REDEEM_FEE!(),
+        &clock,
+        scenario.ctx(),
+    );
+
+    ctr.propose_utxos(redeem_id, vector[0u64], &clock);
+    clock.increment_for_testing(ctr.redeem_duration() + 1);
+    ctr.solve_redeem_request(redeem_id, &clock);
+
+    let request_mut = ctr.redeem_request_mut(redeem_id);
+    let mock_sig = MOCK_SIGNATURE!();
+    request_mut.update_to_signed_for_test(vector[mock_sig]);
+
+    let r = ctr.redeem_request(redeem_id);
+    let tx = r.compose_tx(ctr.storage());
+    let tx_id = tx.tx_id();
+
+    let parent_hash = lc.head_hash();
+    let header = bitcoin_lib::header::create_header_for_test(
+        x"00000020",
+        parent_hash,
+        tx_id,
+        x"132ae858",
+        x"ffff7f20",
+        x"01000011",
+    );
+    lc.insert_headers(vector[header]);
+
+    assert_eq!(ctr.storage().is_inactive(other_dwallet_id), false);
+
+    ctr.finalize_migration(&lc, redeem_id, vector[], 1, 0);
+
+    nbtc::deactivate_dwallet(&admin_cap, &mut ctr, other_dwallet_id);
+
+    assert_eq!(ctr.storage().is_inactive(other_dwallet_id), true);
+
+    let utxo_store = ctr.borrow_utxo_map_for_test();
+    assert_eq!(utxo_store.contains(1), true);
+    let new_utxo = utxo_store.get_utxo(1);
+    assert_eq!(new_utxo.dwallet_id() == recommended_dwallet_id, true);
+
+    clock.destroy_for_testing();
+    destroy(lc);
+    destroy(ctr);
+    destroy(admin_cap);
+    destroy(_dwallet_coordinator);
+    scenario.end();
+}


### PR DESCRIPTION
## Description

Closes: #XXXX

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] added appropriate labels to the PR
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included doc comments for public functions
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary

## Summary by Sourcery

Add support for migrating UTXOs between distributed wallets via dedicated redeem requests and finalize flow.

New Features:
- Introduce migration-specific redeem requests and flows for consolidating UTXOs into the recommended distributed wallet.
- Emit events when migration requests are created and when migrations are finalized to track movement of funds.
- Add admin entrypoint to migrate selected UTXOs and a dedicated function to finalize migrations once the corresponding Bitcoin transaction is confirmed.

Enhancements:
- Guard standard redeem finalization from being used with migration requests to avoid incorrect processing.
- Extend redeem requests with a migration flag and default values needed for migration-specific handling.
- Add test-only helpers to create and inspect migration requests and events and to deactivate dwallets for testing.

Tests:
- Add comprehensive migration unit tests covering request creation, multi-UTXO aggregation, invalid use of standard redeem finalization, supply invariance, and interaction with dwallet deactivation.